### PR TITLE
Reworked queue handling and resource deletion is now queued

### DIFF
--- a/examples/2d-squares/main.rs
+++ b/examples/2d-squares/main.rs
@@ -6,8 +6,8 @@ extern crate nitrogen;
 extern crate rand;
 extern crate winit;
 
-extern crate log;
 extern crate env_logger;
+extern crate log;
 
 use nitrogen::*;
 
@@ -128,12 +128,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ctx.material_write_instance(instance_material, std::iter::once(write));
     }
 
-    let (graph) = create_graph(&mut ctx, vtx_def, material, instance_material, vertex_buffer);
+    let (graph) = create_graph(
+        &mut ctx,
+        vtx_def,
+        material,
+        instance_material,
+        vertex_buffer,
+    );
 
     let mut running = true;
     let mut resized = true;
-
-
 
     let mut exec_context = {
         let initial_size = window.get_inner_size().unwrap();
@@ -142,10 +146,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    let mut submits = vec![
-        ctx.create_submit_group(),
-        ctx.create_submit_group(),
-    ];
+    let mut submits = vec![ctx.create_submit_group(), ctx.create_submit_group()];
 
     let mut flights = Vec::with_capacity(submits.len());
     {
@@ -164,7 +165,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     running = false;
                 }
                 winit::WindowEvent::Resized(size) => {
-
                     exec_context.reference_size = (size.width as u32, size.height as u32);
 
                     resized = true;
@@ -194,7 +194,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ctx.graph_exec_resource_destroy(res);
             }
         }
-
 
         let res = {
             let res = submits[frame_idx].graph_render(&mut ctx, graph, &exec_context);
@@ -308,7 +307,10 @@ fn create_graph(
             }
         }
 
-        let pass = Pass2D { buffer, mat_instance, };
+        let pass = Pass2D {
+            buffer,
+            mat_instance,
+        };
 
         ctx.graph_add_pass(graph, "2D Pass", info, Box::new(pass));
     }
@@ -327,8 +329,6 @@ fn create_instance_data(num: u32) -> Vec<InstanceData> {
 
     for _i in 0..num {
         let size = [rng.gen_range(0.05, 0.1), rng.gen_range(0.05, 0.1)];
-
-
 
         let pos = [
             rng.gen_range(-1.0, 1.0 - size[0]),
@@ -367,7 +367,6 @@ fn update_instance_data(data: &mut [InstanceData], velocities: &mut [[f32; 2]]) 
     assert_eq!(data.len(), velocities.len());
 
     for i in 0..data.len() {
-
         let mut new_pos = [
             data[i].pos[0] + velocities[i][0],
             data[i].pos[1] + velocities[i][1],
@@ -383,7 +382,6 @@ fn update_instance_data(data: &mut [InstanceData], velocities: &mut [[f32; 2]]) 
         }
 
         data[i].pos = new_pos;
-
     }
 }
 

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -74,7 +74,6 @@ fn main() {
             compile(&mut compiler, shader, &out_base, ShaderKind::Compute);
         }
     }
-
 }
 
 pub fn compile(compiler: &mut Compiler, path: PathBuf, out_base: &PathBuf, kind: ShaderKind) {
@@ -119,13 +118,14 @@ pub fn compile(compiler: &mut Compiler, path: PathBuf, out_base: &PathBuf, kind:
         let mut new_name = path.file_name().unwrap().to_string_lossy().to_string();
 
         if lang == SourceLanguage::HLSL {
-            new_name = new_name + match kind {
-                ShaderKind::Vertex => ".vert",
-                ShaderKind::Fragment => ".frag",
-                ShaderKind::Geometry => ".geom",
-                ShaderKind::Compute => ".comp",
-                _ => unreachable!(),
-            };
+            new_name = new_name
+                + match kind {
+                    ShaderKind::Vertex => ".vert",
+                    ShaderKind::Fragment => ".frag",
+                    ShaderKind::Geometry => ".geom",
+                    ShaderKind::Compute => ".comp",
+                    _ => unreachable!(),
+                };
         }
 
         let new_name = new_name + ".spirv";

--- a/examples/two-pass/main.rs
+++ b/examples/two-pass/main.rs
@@ -50,6 +50,8 @@ fn main() {
 
     let mut ntg = nitrogen::Context::new("nitrogen test", 1);
 
+    let mut submit = ntg.create_submit_group();
+
     let display = ntg.add_display(&window);
 
     let material = {
@@ -106,7 +108,7 @@ fn main() {
                 target_offset: (0, 0, 0),
             };
 
-            ntg.image_upload_data(&[(img, data)]).remove(0).unwrap()
+            submit.image_upload_data(&mut ntg, &[(img, data)]).remove(0).unwrap()
         }
 
         drop(image);
@@ -145,7 +147,7 @@ fn main() {
             data: &TRIANGLE,
         };
 
-        let result = ntg.buffer_upload_data(&[(buffer, upload_data)]).remove(0);
+        let result = submit.buffer_upload_data(&mut ntg, &[(buffer, upload_data)]).remove(0);
 
         println!("{:?}", result);
 
@@ -211,7 +213,7 @@ fn main() {
             data: &[uniform_data],
         };
 
-        let result = ntg.buffer_upload_data(&[(buffer, upload_data)]).remove(0);
+        let result = submit.buffer_upload_data(&mut ntg, &[(buffer, upload_data)]).remove(0);
 
         println!("{:?}", result);
 
@@ -241,7 +243,7 @@ fn main() {
         );
     }
 
-    let mut submits = vec![ntg.create_submit_group(), ntg.create_submit_group()];
+    let mut submits = vec![submit, ntg.create_submit_group()];
 
     let mut flights = Vec::with_capacity(submits.len());
     {

--- a/examples/two-pass/main.rs
+++ b/examples/two-pass/main.rs
@@ -9,8 +9,8 @@ extern crate nitrogen;
 extern crate winit;
 
 use nitrogen::graph;
-use nitrogen::image;
 use nitrogen::graph::PassImpl;
+use nitrogen::image;
 
 use log::debug;
 
@@ -241,10 +241,7 @@ fn main() {
         );
     }
 
-    let mut submits = vec![
-        ntg.create_submit_group(),
-        ntg.create_submit_group(),
-    ];
+    let mut submits = vec![ntg.create_submit_group(), ntg.create_submit_group()];
 
     let mut flights = Vec::with_capacity(submits.len());
     {
@@ -360,11 +357,17 @@ fn setup_graphs(
     {
         let shaders = nitrogen::graph::Shaders {
             vertex: nitrogen::graph::ShaderInfo {
-                content: Cow::Borrowed(include_bytes!(concat!(env!("OUT_DIR"), "/two-pass/test.hlsl.vert.spirv"))),
+                content: Cow::Borrowed(include_bytes!(concat!(
+                    env!("OUT_DIR"),
+                    "/two-pass/test.hlsl.vert.spirv"
+                ))),
                 entry: "VertexMain".into(),
             },
             fragment: Some(nitrogen::graph::ShaderInfo {
-                content: Cow::Borrowed(include_bytes!(concat!(env!("OUT_DIR"), "/two-pass/test.hlsl.frag.spirv"))),
+                content: Cow::Borrowed(include_bytes!(concat!(
+                    env!("OUT_DIR"),
+                    "/two-pass/test.hlsl.frag.spirv"
+                ))),
                 entry: "FragmentMain".into(),
             }),
             geometry: None,
@@ -396,11 +399,17 @@ fn setup_graphs(
     {
         let shaders = nitrogen::graph::Shaders {
             vertex: nitrogen::graph::ShaderInfo {
-                content: Cow::Borrowed(include_bytes!(concat!(env!("OUT_DIR"), "/two-pass/read.hlsl.vert.spirv"))),
+                content: Cow::Borrowed(include_bytes!(concat!(
+                    env!("OUT_DIR"),
+                    "/two-pass/read.hlsl.vert.spirv"
+                ))),
                 entry: "VertexMain".into(),
             },
             fragment: Some(nitrogen::graph::ShaderInfo {
-                content: Cow::Borrowed(include_bytes!(concat!(env!("OUT_DIR"), "/two-pass/read.hlsl.frag.spirv"))),
+                content: Cow::Borrowed(include_bytes!(concat!(
+                    env!("OUT_DIR"),
+                    "/two-pass/read.hlsl.frag.spirv"
+                ))),
                 entry: "FragmentMain".into(),
             }),
             geometry: None,
@@ -409,7 +418,6 @@ fn setup_graphs(
         let (pass_impl, info) = create_test_pass(
             shaders,
             |builder| {
-
                 builder.image_create("IOutput", image_create_info());
 
                 builder.image_write_color("IOutput", 0);

--- a/nitrogen-ffi/src/image.rs
+++ b/nitrogen-ffi/src/image.rs
@@ -220,6 +220,7 @@ pub unsafe extern "C" fn image_upload_data(
             (handle, upload_info)
         })
         .collect::<SmallVec<[_; 16]>>();
+    /*
 
     let results = context.image_storage.upload_data(
         &context.device_ctx,
@@ -230,6 +231,7 @@ pub unsafe extern "C" fn image_upload_data(
     for (i, result) in results.into_iter().enumerate() {
         successes[i] = result.is_ok();
     }
+    */
 }
 
 #[no_mangle]

--- a/nitrogen-ffi/src/image.rs
+++ b/nitrogen-ffi/src/image.rs
@@ -249,5 +249,5 @@ pub unsafe extern "C" fn image_destroy(
         .map(|image| (*image).into())
         .collect::<Vec<_>>();
 
-    context.image_storage.destroy(&context.device_ctx, &images);
+    // context.image_storage.destroy(&context.device_ctx, &images);
 }

--- a/nitrogen-ffi/src/image.rs
+++ b/nitrogen-ffi/src/image.rs
@@ -164,7 +164,8 @@ pub unsafe extern "C" fn image_create(
 
                 is_transient: create_info.is_transient,
             }
-        }).collect::<SmallVec<[_; 16]>>();
+        })
+        .collect::<SmallVec<[_; 16]>>();
 
     let results = context
         .image_storage
@@ -217,7 +218,8 @@ pub unsafe extern "C" fn image_upload_data(
             };
 
             (handle, upload_info)
-        }).collect::<SmallVec<[_; 16]>>();
+        })
+        .collect::<SmallVec<[_; 16]>>();
 
     let results = context.image_storage.upload_data(
         &context.device_ctx,

--- a/nitrogen-ffi/src/lib.rs
+++ b/nitrogen-ffi/src/lib.rs
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn display_setup_swapchain(context: *mut Context, display:
     let device_ctx = &(*context).device_ctx;
     let display_ctx = &mut (*context).displays[display.into()];
 
-    display_ctx.setup_swapchain(device_ctx);
+    // display_ctx.setup_swapchain(device_ctx);
 }
 
 #[no_mangle]

--- a/nitrogen-ffi/src/sampler.rs
+++ b/nitrogen-ffi/src/sampler.rs
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn sampler_destroy(
         .map(|s| SamplerHandle::into(s.clone()))
         .collect::<SmallVec<[_; 16]>>();
 
-    context
-        .sampler_storage
-        .destroy(&context.device_ctx, samplers.as_slice());
+    // context
+    //     .sampler_storage
+    //     .destroy(&context.device_ctx, samplers.as_slice());
 }

--- a/nitrogen-ffi/src/sampler.rs
+++ b/nitrogen-ffi/src/sampler.rs
@@ -96,7 +96,8 @@ pub unsafe extern "C" fn sampler_create(
         .map(|c| {
             let create_info = Into::<sampler::SamplerCreateInfo>::into(*c);
             create_info
-        }).collect::<SmallVec<[_; 16]>>();
+        })
+        .collect::<SmallVec<[_; 16]>>();
 
     let sampler_handles = context
         .sampler_storage

--- a/nitrogen/build.rs
+++ b/nitrogen/build.rs
@@ -108,13 +108,14 @@ pub fn compile(compiler: &mut Compiler, path: PathBuf, kind: ShaderKind) {
         let mut new_name = path.file_name().unwrap().to_string_lossy().to_string();
 
         if lang == SourceLanguage::HLSL {
-            new_name = new_name + match kind {
-                ShaderKind::Vertex => ".vert",
-                ShaderKind::Fragment => ".frag",
-                ShaderKind::Geometry => ".geom",
-                ShaderKind::Compute => ".comp",
-                _ => unreachable!(),
-            };
+            new_name = new_name
+                + match kind {
+                    ShaderKind::Vertex => ".vert",
+                    ShaderKind::Fragment => ".frag",
+                    ShaderKind::Geometry => ".geom",
+                    ShaderKind::Compute => ".comp",
+                    _ => unreachable!(),
+                };
         }
 
         let new_name = new_name + ".spirv";

--- a/nitrogen/src/device.rs
+++ b/nitrogen/src/device.rs
@@ -12,6 +12,10 @@ use gfxm::SmartAllocator;
 
 use back;
 
+use types;
+
+use smallvec::SmallVec;
+
 use std::sync::{Arc, Mutex, MutexGuard};
 
 #[repr(u8)]
@@ -23,7 +27,10 @@ pub enum QueueType {
 pub struct DeviceContext {
     pub memory_allocator: Mutex<SmartAllocator<back::Backend>>,
 
-    pub queue_group: Mutex<gfx::QueueGroup<back::Backend, gfx::General>>,
+    pub graphics_queue_idx: usize,
+    pub compute_queue_idx: usize,
+    pub queue_groups: SmallVec<[types::QueueGroup<gfx::Transfer>; 2]>,
+    pub queues: SmallVec<[Vec<Mutex<types::CommandQueue<gfx::Transfer>>>; 2]>,
 
     pub device: Arc<back::Device>,
     pub adapter: Arc<gfx::Adapter<back::Backend>>,
@@ -32,6 +39,7 @@ pub struct DeviceContext {
 impl DeviceContext {
     pub fn new(instance: &back::Instance) -> Self {
         use gfx::PhysicalDevice;
+        use std::mem::replace;
 
         let mut adapters = instance.enumerate_adapters();
 
@@ -42,74 +50,76 @@ impl DeviceContext {
         let memory_allocator =
             SmartAllocator::new(memory_properties, 256, 64, 1024, 256 * 1024 * 1024);
 
-        //        TODO better queue handling than just requiring a `General` queue.
-        //
-        //        let (device, queues) = {
-        //            let mut display_queues = vec![];
-        //            let mut render_queues = vec![];
-        //            let mut compute_queues = vec![];
-        //
-        //            adapter
-        //                .queue_families
-        //                .iter()
-        //                .enumerate()
-        //                .for_each(|(idx, family)| {
-        //                    for surface in surfaces {
-        //                        if surface.supports_queue_family(family) {
-        //                            display_queues.push(family);
-        //                        }
-        //                    }
-        //
-        //                    if family.supports_graphics() {
-        //                        render_queues.push(family);
-        //                    }
-        //                    if family.supports_compute() {
-        //                        compute_queues.push(family);
-        //                    }
-        //                });
-        //
-        //            let queue_for_display = display_queues[0]; // TODO have proper selection?
-        //            let queue_for_rendering = render_queues[0]; // TODO have a proper selection?
-        //            let queue_for_compute = compute_queues[0]; // TODO have proper selection?
-        //
-        //            // deduplicate queues
-        //            let mut families = [
-        //                queue_for_rendering,
-        //                queue_for_display,
-        //                queue_for_compute,
-        //            ];
-        //
-        //            let families = families
-        //                .iter()
-        //                .map(|fam| (*fam, &[1.0; 1][..]))
-        //                .collect::<Vec<_>>();
-        //
-        //            let mut gpu: gfx::Gpu<back::Backend> = adapter
-        //                .physical_device
-        //                .open(&families[..])
-        //                .expect("Can't open device");
-        //
-        //            let render_queue = gpu.queues.take::<gfx::Graphics>(queue_for_rendering.id());
-        //            let display_queue = gpu.queues.take::<gfx::Graphics>(queue_for_display.id());
-        //            let compute_queue = gpu.queues.take::<gfx::Compute>(queue_for_compute.id());
-        //
-        //            (gpu.device, gpu.queues)
-        //        };
+        let (device, mut queue_groups, graphics_idx, compute_idx) = {
+            use gfx::QueueFamily;
 
-        let (device, queue_group) = adapter
-            .open_with(1, |family| {
-                // surfaces.iter().fold(true, |acc, surface| {
-                //     surface.supports_queue_family(family) && acc
-                // })
-                use gfx::QueueFamily;
-                family.supports_graphics() && family.supports_compute()
+            let graphics_queue = adapter
+                .queue_families
+                .iter()
+                .filter(|fam| fam.supports_graphics())
+                .max_by_key(|fam| fam.max_queues())
+                .expect("No suitable graphics queue available");
+
+            let compute_queue = adapter
+                .queue_families
+                .iter()
+                .filter(|fam| fam.supports_compute())
+                .max_by_key(|fam| fam.max_queues())
+                .expect("No suitable compute queue available");
+
+            // create device, for that we need a list of all the queues we want to be created.
+            let queues: &[(_, &[_])] = &[(graphics_queue, &[1.0]), (compute_queue, &[1.0])];
+
+            // Here we only have two queues we found out are compatible.
+            // But those things might point to the same queue! Unfortunately Vulkan doesn't like
+            // when you ask it to create two queues which are actually the same queue.
+            // Because of that we have to de-duplicate the queue list. Fortunately here we only have
+            // two things that could alias each other, so when they are the same we just ignore one
+            // of them.
+            let end = if graphics_queue.id() == compute_queue.id() {
+                1
+            } else {
+                2
+            };
+
+            let mut gpu = adapter
+                .physical_device
+                .open(&queues[0..end])
+                .expect("Can't create logical device");
+
+            let mut queues = SmallVec::new();
+            queues.push(gpu.queues.take(graphics_queue.id()).unwrap());
+
+            let graphics_idx = 0;
+
+            let compute_idx = if compute_queue.id() != graphics_queue.id() {
+                queues.push(gpu.queues.take(compute_queue.id()).unwrap());
+
+                1
+            } else {
+                0
+            };
+
+            (gpu.device, queues, graphics_idx, compute_idx)
+        };
+
+        let queues = queue_groups
+            .as_mut_slice()
+            .iter_mut()
+            .map(|group: &mut gfx::QueueGroup<_, _>| {
+                let queues = replace(&mut group.queues, vec![]);
+
+                queues.into_iter().map(|queue| Mutex::new(queue)).collect()
             })
-            .unwrap();
+            .collect();
 
         DeviceContext {
             memory_allocator: Mutex::new(memory_allocator),
 
-            queue_group: Mutex::new(queue_group),
+            graphics_queue_idx: graphics_idx,
+            compute_queue_idx: compute_idx,
+            queue_groups,
+            queues,
 
             device: Arc::new(device),
             adapter: Arc::new(adapter),
@@ -123,8 +133,69 @@ impl DeviceContext {
             .expect("Memory allocator can't be accessed")
     }
 
-    pub fn queue_group(&self) -> MutexGuard<gfx::QueueGroup<back::Backend, gfx::General>> {
-        self.queue_group.lock().unwrap()
+    pub fn graphics_queue_group(&self) -> &types::QueueGroup<gfx::Graphics> {
+        use std::mem::transmute;
+
+        let queue = &self.queue_groups[self.graphics_queue_idx];
+
+        unsafe { transmute(queue) }
+    }
+
+    pub fn graphics_queue_group_mut(&mut self) -> &mut types::QueueGroup<gfx::Graphics> {
+        use std::mem::transmute;
+
+        let queue = &mut self.queue_groups[self.graphics_queue_idx];
+
+        unsafe { transmute(queue) }
+    }
+
+    pub fn graphics_queue(&self) -> MutexGuard<types::CommandQueue<gfx::Graphics>> {
+        use std::mem::transmute;
+        unsafe { transmute(self.queues[self.graphics_queue_idx][0].lock().unwrap()) }
+    }
+
+    pub fn compute_queue_group(&self) -> &types::QueueGroup<gfx::Compute> {
+        use std::mem::transmute;
+
+        let queue = &self.queue_groups[self.compute_queue_idx];
+
+        unsafe { transmute(queue) }
+    }
+
+    pub fn compute_queue_group_mut(&mut self) -> &mut types::QueueGroup<gfx::Compute> {
+        use std::mem::transmute;
+
+        let queue = &mut self.queue_groups[self.compute_queue_idx];
+
+        unsafe { transmute(queue) }
+    }
+
+    pub fn compute_queue(&self) -> MutexGuard<types::CommandQueue<gfx::Compute>> {
+        use std::mem::transmute;
+        unsafe { transmute(self.queues[self.compute_queue_idx][0].lock().unwrap()) }
+    }
+
+    pub fn transfer_queue_group(&self) -> &types::QueueGroup<gfx::Transfer> {
+        use std::mem::transmute;
+
+        // TODO find the "best" queue to use.
+        let queue = &self.queue_groups[self.compute_queue_idx];
+
+        unsafe { transmute(queue) }
+    }
+
+    pub fn transfer_queue_group_mut(&mut self) -> &mut types::QueueGroup<gfx::Transfer> {
+        use std::mem::transmute;
+
+        // TODO find the "best" queue to use.
+        let queue = &mut self.queue_groups[self.compute_queue_idx];
+
+        unsafe { transmute(queue) }
+    }
+
+    pub fn transfer_queue(&self) -> MutexGuard<types::CommandQueue<gfx::Transfer>> {
+        use std::mem::transmute;
+        unsafe { transmute(self.queues[self.compute_queue_idx][0].lock().unwrap()) }
     }
 
     pub fn release(self) {

--- a/nitrogen/src/display.rs
+++ b/nitrogen/src/display.rs
@@ -424,6 +424,8 @@ impl Display {
 
             sem_list.add_next_semaphore(sem_blit);
 
+            let mut queue = device.graphics_queue();
+
             {
                 let submission = gfx::Submission::new()
                     .wait_on(
@@ -434,15 +436,11 @@ impl Display {
                     .signal(&[&*sem_present])
                     .signal(sem_pool.list_next_sems(sem_list))
                     .submit(Some(submit));
-                device.queue_group().queues[0].submit(submission, None);
+                queue.submit(submission, None);
             }
 
             let res = swapchain
-                .present(
-                    &mut device.queue_group().queues[0],
-                    index,
-                    std::iter::once(sem_present),
-                )
+                .present(&mut *queue, index, std::iter::once(sem_present))
                 .is_ok();
 
             res

--- a/nitrogen/src/graph/execution.rs
+++ b/nitrogen/src/graph/execution.rs
@@ -35,6 +35,7 @@ use resources::{
     semaphore_pool::{Semaphore, SemaphoreList, SemaphorePool},
     vertex_attrib::{VertexAttribHandle, VertexAttribStorage},
 };
+use submit_group::ResourceList;
 
 #[derive(Debug, Clone)]
 pub struct ExecutionBatch {
@@ -286,7 +287,7 @@ pub struct ExecutionResources {
 impl ExecutionResources {
     pub fn release(
         self,
-        device: &DeviceContext,
+        res_list: &mut ResourceList,
         image: &mut ImageStorage,
         sampler: &mut SamplerStorage,
         buffer: &mut BufferStorage,
@@ -294,14 +295,8 @@ impl ExecutionResources {
         use smallvec::SmallVec;
 
         {
-            for (_, f) in self.framebuffers {
-                device.device.destroy_framebuffer(f);
-            }
-        }
-
-        {
             let images = self.images.values().cloned().collect::<SmallVec<[_; 16]>>();
-            image.destroy(device, images.as_slice());
+            image.destroy(res_list, images.as_slice());
         }
 
         {
@@ -310,7 +305,7 @@ impl ExecutionResources {
                 .values()
                 .cloned()
                 .collect::<SmallVec<[_; 16]>>();
-            sampler.destroy(device, samplers.as_slice());
+            sampler.destroy(res_list, samplers.as_slice());
         }
 
         {
@@ -319,7 +314,7 @@ impl ExecutionResources {
                 .values()
                 .cloned()
                 .collect::<SmallVec<[_; 16]>>();
-            buffer.destroy(device, buffers.as_slice());
+            buffer.destroy(res_list, buffers.as_slice());
         }
     }
 }
@@ -592,7 +587,8 @@ pub(crate) fn execute(
     device: &DeviceContext,
     sem_pool: &mut SemaphorePool,
     sem_list: &mut SemaphoreList,
-    command_pool: &mut CommandPool<gfx::Graphics>,
+    cmd_pool: &mut CommandPool<gfx::Graphics>,
+    res_list: &mut ResourceList,
     storages: &mut ExecutionStorages,
     exec_graph: &ExecutionGraph,
     resolved_graph: &GraphResourcesResolved,
@@ -880,7 +876,7 @@ pub(crate) fn execute(
                 )];
 
                 let submit = {
-                    let mut raw_cmd = command_pool.acquire_command_buffer(false);
+                    let mut raw_cmd = cmd_pool.acquire_command_buffer(false);
                     raw_cmd.bind_graphics_pipeline(&pipeline.pipeline);
 
                     raw_cmd.set_viewports(0, &[viewport.clone()]);
@@ -926,12 +922,12 @@ pub(crate) fn execute(
         }
 
         // destroy resources
-        if false {
+        {
             // destroy framebuffers first
             for pass in &batch.passes {
                 let framebuffer = res.framebuffers.remove(pass).unwrap();
 
-                device.device.destroy_framebuffer(framebuffer);
+                res_list.queue_framebuffer(framebuffer);
             }
 
             // destroy images and samplers
@@ -939,10 +935,10 @@ pub(crate) fn execute(
                 if let Some(img) = res.images.remove(res_id) {
                     let sampler = res.samplers.remove(res_id);
                     if let Some(sampler) = sampler {
-                        storages.sampler.destroy(device, &[sampler]);
+                        storages.sampler.destroy(res_list, &[sampler]);
                     }
 
-                    storages.image.destroy(device, &[img]);
+                    storages.image.destroy(res_list, &[img]);
                 }
             }
         }

--- a/nitrogen/src/graph/execution.rs
+++ b/nitrogen/src/graph/execution.rs
@@ -918,7 +918,7 @@ pub(crate) fn execute(
                         )
                         .signal(sem_pool.list_next_sems(sem_list))
                         .submit(Some(submit));
-                    device.queue_group().queues[0].submit(submission, None);
+                    device.graphics_queue().submit(submission, None);
                 }
 
                 sem_list.advance();

--- a/nitrogen/src/graph/mod.rs
+++ b/nitrogen/src/graph/mod.rs
@@ -37,6 +37,7 @@ pub use self::command::*;
 mod execution;
 pub use self::execution::ExecutionResources;
 use self::execution::*;
+use submit_group::ResourceList;
 
 pub type GraphHandle = Handle<Graph>;
 
@@ -355,7 +356,8 @@ impl GraphStorage {
         device: &DeviceContext,
         sem_pool: &mut SemaphorePool,
         sem_list: &mut SemaphoreList,
-        command_pool: &mut CommandPool<gfx::Graphics>,
+        cmd_pool: &mut CommandPool<gfx::Graphics>,
+        res_list: &mut ResourceList,
         render_pass_storage: &mut RenderPassStorage,
         pipeline_storage: &mut PipelineStorage,
         image_storage: &mut ImageStorage,
@@ -422,7 +424,8 @@ impl GraphStorage {
             device,
             sem_pool,
             sem_list,
-            command_pool,
+            cmd_pool,
+            res_list,
             &mut storages,
             exec,
             resolved,

--- a/nitrogen/src/lib.rs
+++ b/nitrogen/src/lib.rs
@@ -87,7 +87,7 @@ impl Context {
         let instance = back::Instance::create(name, version);
         let device_ctx = Arc::new(DeviceContext::new(&instance));
 
-        let transfer = transfer::TransferContext::new(&device_ctx);
+        let transfer = transfer::TransferContext::new();
 
         let image_storage = image::ImageStorage::new();
         let sampler_storage = sampler::SamplerStorage::new();
@@ -177,7 +177,7 @@ impl Context {
             display.release(&self.device_ctx);
         }
 
-        self.transfer.release(&self.device_ctx);
+        self.transfer.release();
 
         Arc::try_unwrap(self.device_ctx).ok().unwrap().release();
     }
@@ -191,14 +191,6 @@ impl Context {
         create_infos: &[image::ImageCreateInfo<image::ImageUsage>],
     ) -> SmallVec<[image::Result<image::ImageHandle>; 16]> {
         self.image_storage.create(&self.device_ctx, create_infos)
-    }
-
-    pub fn image_upload_data(
-        &mut self,
-        images: &[(image::ImageHandle, image::ImageUploadInfo)],
-    ) -> SmallVec<[image::Result<()>; 16]> {
-        self.image_storage
-            .upload_data(&self.device_ctx, &mut self.transfer, images)
     }
 
     pub fn image_destroy(&mut self, handles: &[image::ImageHandle]) {
@@ -229,14 +221,6 @@ impl Context {
 
     pub fn buffer_destroy(&mut self, buffers: &[buffer::BufferHandle]) {
         self.buffer_storage.destroy(&self.device_ctx, buffers)
-    }
-
-    pub fn buffer_upload_data<T>(
-        &mut self,
-        data: &[(buffer::BufferHandle, buffer::BufferUploadInfo<T>)],
-    ) -> SmallVec<[buffer::Result<()>; 16]> {
-        self.buffer_storage
-            .upload_data(&self.device_ctx, &mut self.transfer, data)
     }
 
     // vertex attribs

--- a/nitrogen/src/lib.rs
+++ b/nitrogen/src/lib.rs
@@ -193,10 +193,6 @@ impl Context {
         self.image_storage.create(&self.device_ctx, create_infos)
     }
 
-    pub fn image_destroy(&mut self, handles: &[image::ImageHandle]) {
-        self.image_storage.destroy(&self.device_ctx, handles)
-    }
-
     // sampler
 
     pub fn sampler_create(
@@ -206,10 +202,6 @@ impl Context {
         self.sampler_storage.create(&self.device_ctx, create_infos)
     }
 
-    pub fn sampler_destroy(&mut self, handles: &[sampler::SamplerHandle]) {
-        self.sampler_storage.destroy(&self.device_ctx, handles)
-    }
-
     // buffer
 
     pub fn buffer_create(
@@ -217,10 +209,6 @@ impl Context {
         create_infos: &[buffer::BufferCreateInfo],
     ) -> SmallVec<[buffer::Result<buffer::BufferHandle>; 16]> {
         self.buffer_storage.create(&self.device_ctx, create_infos)
-    }
-
-    pub fn buffer_destroy(&mut self, buffers: &[buffer::BufferHandle]) {
-        self.buffer_storage.destroy(&self.device_ctx, buffers)
     }
 
     // vertex attribs
@@ -323,15 +311,6 @@ impl Context {
         graph: graph::GraphHandle,
     ) -> Result<(), Vec<graph::GraphCompileError>> {
         self.graph_storage.compile(graph)
-    }
-
-    pub fn graph_exec_resource_destroy(&mut self, exec_res: graph::ExecutionResources) {
-        exec_res.release(
-            &self.device_ctx,
-            &mut self.image_storage,
-            &mut self.sampler_storage,
-            &mut self.buffer_storage,
-        );
     }
 
     // submit group

--- a/nitrogen/src/resources/buffer.rs
+++ b/nitrogen/src/resources/buffer.rs
@@ -28,6 +28,7 @@ use resources::MemoryProperties;
 
 use resources::semaphore_pool::SemaphoreList;
 use resources::semaphore_pool::SemaphorePool;
+use submit_group::ResourceList;
 use types;
 use types::CommandPool;
 
@@ -244,12 +245,11 @@ impl BufferStorage {
         results
     }
 
-    pub fn destroy(&mut self, device: &DeviceContext, buffers: &[BufferHandle]) {
-        let mut allocator = device.allocator();
+    pub fn destroy(&mut self, res_list: &mut ResourceList, buffers: &[BufferHandle]) {
         for handle in buffers {
             let id = handle.id();
             let buffer = self.buffers.remove(&id).unwrap();
-            allocator.destroy_buffer(&device.device, buffer.buffer);
+            res_list.queue_buffer(buffer.buffer);
         }
     }
 
@@ -265,6 +265,7 @@ impl BufferStorage {
         sem_pool: &SemaphorePool,
         sem_list: &mut SemaphoreList,
         cmd_pool: &mut CommandPool<gfx::Transfer>,
+        res_list: &mut ResourceList,
         transfer: &TransferContext,
         data: &[(BufferHandle, BufferUploadInfo<T>)],
     ) -> SmallVec<[Result<()>; 16]> {
@@ -426,12 +427,7 @@ impl BufferStorage {
         }
 
         staging_data.into_iter().for_each(|(_, _, _, staging)| {
-            // FIXME destroy only after the submit group is done
-            // FIXME
-            // FIXME DO IT THOMAS
-            // FIXME
-            // FIXME You know you have to do it eventually
-            allocator.destroy_buffer(&device.device, staging);
+            res_list.queue_buffer(staging);
         });
 
         results

--- a/nitrogen/src/resources/image.rs
+++ b/nitrogen/src/resources/image.rs
@@ -27,6 +27,7 @@ use transfer::TransferContext;
 use device::DeviceContext;
 use resources::semaphore_pool::SemaphoreList;
 use resources::semaphore_pool::SemaphorePool;
+use submit_group::ResourceList;
 use types::CommandPool;
 
 #[derive(Copy, Clone, Debug)]
@@ -371,6 +372,7 @@ impl ImageStorage {
         sem_pool: &SemaphorePool,
         sem_list: &mut SemaphoreList,
         cmd_pool: &mut CommandPool<gfx::Transfer>,
+        res_list: &mut ResourceList,
         transfer: &TransferContext,
         images: &[(ImageHandle, ImageUploadInfo)],
     ) -> SmallVec<[Result<()>; 16]> {
@@ -596,7 +598,7 @@ impl ImageStorage {
         staging_data
             .into_iter()
             .for_each(|(_, _, _, staging_buffer, _, _)| {
-                allocator.destroy_buffer(&device.device, staging_buffer);
+                res_list.queue_buffer(staging_buffer);
             });
 
         results
@@ -610,14 +612,12 @@ impl ImageStorage {
         }
     }
 
-    pub fn destroy(&mut self, device: &DeviceContext, handles: &[ImageHandle]) {
-        let mut allocator = device.allocator();
-
+    pub fn destroy(&mut self, res_list: &mut ResourceList, handles: &[ImageHandle]) {
         for handle in handles {
             match self.storage.remove(*handle) {
                 Some(image) => {
-                    allocator.destroy_image(&device.device, image.image);
-                    device.device.destroy_image_view(image.view);
+                    res_list.queue_image(image.image);
+                    res_list.queue_image_view(image.view);
 
                     if self.transfer_dst.contains(&handle.id()) {
                         self.transfer_dst.remove(&handle.id());

--- a/nitrogen/src/resources/sampler.rs
+++ b/nitrogen/src/resources/sampler.rs
@@ -12,6 +12,7 @@ use util::storage::Storage;
 
 use smallvec::SmallVec;
 
+use submit_group::ResourceList;
 use types::Sampler;
 
 #[derive(Copy, Clone)]
@@ -122,11 +123,11 @@ impl SamplerStorage {
         }
     }
 
-    pub fn destroy(&mut self, device: &DeviceContext, handles: &[SamplerHandle]) {
+    pub fn destroy(&mut self, res_list: &mut ResourceList, handles: &[SamplerHandle]) {
         for handle in handles {
             match self.storage.remove(*handle) {
                 Some(sampler) => {
-                    device.device.destroy_sampler(sampler);
+                    res_list.queue_sampler(sampler);
                 }
                 None => {}
             }

--- a/nitrogen/src/types.rs
+++ b/nitrogen/src/types.rs
@@ -22,3 +22,5 @@ pub type ShaderModule = <back::Backend as gfx::Backend>::ShaderModule;
 pub type Semaphore = <back::Backend as gfx::Backend>::Semaphore;
 pub type Fence = <back::Backend as gfx::Backend>::Fence;
 pub type CommandPool<T> = gfx::CommandPool<back::Backend, T>;
+pub type QueueGroup<T> = gfx::QueueGroup<back::Backend, T>;
+pub type CommandQueue<T> = gfx::CommandQueue<back::Backend, T>;

--- a/nitrogen/src/types.rs
+++ b/nitrogen/src/types.rs
@@ -18,6 +18,7 @@ pub type Framebuffer = <back::Backend as gfx::Backend>::Framebuffer;
 pub type RenderPass = <back::Backend as gfx::Backend>::RenderPass;
 pub type Image = <back::Backend as gfx::Backend>::Image;
 pub type ImageView = <back::Backend as gfx::Backend>::ImageView;
+pub type Buffer = <back::Backend as gfx::Backend>::Buffer;
 pub type ShaderModule = <back::Backend as gfx::Backend>::ShaderModule;
 pub type Semaphore = <back::Backend as gfx::Backend>::Semaphore;
 pub type Fence = <back::Backend as gfx::Backend>::Fence;

--- a/nitrogen/src/util/submit_group.rs
+++ b/nitrogen/src/util/submit_group.rs
@@ -121,6 +121,36 @@ impl SubmitGroup {
         )
     }
 
+    pub fn image_upload_data(
+        &mut self,
+        ctx: &mut Context,
+        images: &[(image::ImageHandle, image::ImageUploadInfo)],
+    ) -> SmallVec<[image::Result<()>; 16]> {
+        ctx.image_storage.upload_data(
+            &ctx.device_ctx,
+            &self.sem_pool,
+            &mut self.sem_list,
+            &mut self.pool_transfer,
+            &ctx.transfer,
+            images,
+        )
+    }
+
+    pub fn buffer_upload_data<T>(
+        &mut self,
+        ctx: &mut Context,
+        data: &[(buffer::BufferHandle, buffer::BufferUploadInfo<T>)],
+    ) -> SmallVec<[buffer::Result<()>; 16]> {
+        ctx.buffer_storage.upload_data(
+            &ctx.device_ctx,
+            &self.sem_pool,
+            &mut self.sem_list,
+            &mut self.pool_transfer,
+            &ctx.transfer,
+            data,
+        )
+    }
+
     pub fn wait(&mut self, ctx: &mut Context) {
         let mut fence = ctx.device_ctx.device.create_fence(false).unwrap();
 
@@ -131,7 +161,9 @@ impl SubmitGroup {
                     .map(|sem| (sem, gfx::pso::PipelineStage::BOTTOM_OF_PIPE)),
             );
 
-            ctx.device_ctx.transfer_queue().submit(submit, Some(&mut fence));
+            ctx.device_ctx
+                .transfer_queue()
+                .submit(submit, Some(&mut fence));
 
             ctx.device_ctx.device.wait_for_fence(&fence, !0);
         }

--- a/nitrogen/src/util/submit_group.rs
+++ b/nitrogen/src/util/submit_group.rs
@@ -30,20 +30,10 @@ pub struct SubmitGroup {
 impl SubmitGroup {
     pub fn new(device: Arc<DeviceContext>) -> Self {
         let (gfx, cmpt, trns) = {
-            use std::ops::Deref;
-
-            // TODO better queue handing AHHHH
-            let queues = device.queue_group();
-            let queues = queues.deref();
-
-            use std::mem::transmute;
-
-            // I am _so_ sorry for all this unsafe :(
-
             let gfx = device
                 .device
                 .create_command_pool_typed(
-                    unsafe { transmute(queues) },
+                    device.graphics_queue_group(),
                     gfx::pool::CommandPoolCreateFlags::empty(),
                     0,
                 )
@@ -51,7 +41,7 @@ impl SubmitGroup {
             let cmpt = device
                 .device
                 .create_command_pool_typed(
-                    unsafe { transmute(queues) },
+                    device.compute_queue_group(),
                     gfx::pool::CommandPoolCreateFlags::empty(),
                     0,
                 )
@@ -59,7 +49,7 @@ impl SubmitGroup {
             let trns = device
                 .device
                 .create_command_pool_typed(
-                    unsafe { transmute(queues) },
+                    device.transfer_queue_group(),
                     gfx::pool::CommandPoolCreateFlags::empty(),
                     0,
                 )
@@ -141,7 +131,7 @@ impl SubmitGroup {
                     .map(|sem| (sem, gfx::pso::PipelineStage::BOTTOM_OF_PIPE)),
             );
 
-            ctx.device_ctx.queue_group().queues[0].submit(submit, Some(&mut fence));
+            ctx.device_ctx.transfer_queue().submit(submit, Some(&mut fence));
 
             ctx.device_ctx.device.wait_for_fence(&fence, !0);
         }

--- a/nitrogen/src/util/submit_group.rs
+++ b/nitrogen/src/util/submit_group.rs
@@ -5,6 +5,9 @@
 use gfx;
 use gfx::Device;
 
+use buffer::BufferTypeInternal;
+use image::ImageType;
+
 use back;
 
 use crate::*;
@@ -25,6 +28,7 @@ pub struct SubmitGroup {
     pool_transfer: types::CommandPool<gfx::Transfer>,
 
     sem_list: SemaphoreList,
+    res_destroys: ResourceList,
 }
 
 impl SubmitGroup {
@@ -63,8 +67,10 @@ impl SubmitGroup {
             pool_compute: cmpt,
             pool_transfer: trns,
 
-            sem_pool: SemaphorePool::new(device),
+            sem_pool: SemaphorePool::new(device.clone()),
             sem_list: SemaphoreList::new(),
+
+            res_destroys: ResourceList::new(device),
         }
     }
 
@@ -94,8 +100,10 @@ impl SubmitGroup {
             &ctx.sampler_storage,
             sampler,
         );
+    }
 
-        self.sem_list.advance()
+    pub fn display_setup_swapchain(&mut self, ctx: &mut Context, display: DisplayHandle) {
+        ctx.displays[display].setup_swapchain(&ctx.device_ctx, &mut self.res_destroys);
     }
 
     pub fn graph_render(
@@ -109,6 +117,7 @@ impl SubmitGroup {
             &mut self.sem_pool,
             &mut self.sem_list,
             &mut self.pool_graphics,
+            &mut self.res_destroys,
             &mut ctx.render_pass_storage,
             &mut ctx.pipeline_storage,
             &mut ctx.image_storage,
@@ -121,6 +130,15 @@ impl SubmitGroup {
         )
     }
 
+    pub fn graph_resources_destroy(&mut self, ctx: &mut Context, res: graph::ExecutionResources) {
+        res.release(
+            &mut self.res_destroys,
+            &mut ctx.image_storage,
+            &mut ctx.sampler_storage,
+            &mut ctx.buffer_storage,
+        );
+    }
+
     pub fn image_upload_data(
         &mut self,
         ctx: &mut Context,
@@ -131,9 +149,14 @@ impl SubmitGroup {
             &self.sem_pool,
             &mut self.sem_list,
             &mut self.pool_transfer,
+            &mut self.res_destroys,
             &ctx.transfer,
             images,
         )
+    }
+
+    pub fn image_destroy(&mut self, ctx: &mut Context, images: &[image::ImageHandle]) {
+        ctx.image_storage.destroy(&mut self.res_destroys, images)
     }
 
     pub fn buffer_upload_data<T>(
@@ -146,9 +169,19 @@ impl SubmitGroup {
             &self.sem_pool,
             &mut self.sem_list,
             &mut self.pool_transfer,
+            &mut self.res_destroys,
             &ctx.transfer,
             data,
         )
+    }
+
+    pub fn buffer_destroy(&mut self, ctx: &mut Context, buffers: &[buffer::BufferHandle]) {
+        ctx.buffer_storage.destroy(&mut self.res_destroys, buffers);
+    }
+
+    pub fn sampler_destroy(&mut self, ctx: &mut Context, samplers: &[sampler::SamplerHandle]) {
+        ctx.sampler_storage
+            .destroy(&mut self.res_destroys, samplers)
     }
 
     pub fn wait(&mut self, ctx: &mut Context) {
@@ -172,6 +205,8 @@ impl SubmitGroup {
 
         ctx.device_ctx.device.destroy_fence(fence);
 
+        self.res_destroys.free_resources();
+
         self.sem_pool.clear();
 
         self.pool_graphics.reset();
@@ -191,5 +226,82 @@ impl SubmitGroup {
             .destroy_command_pool(self.pool_transfer.into_raw());
 
         self.sem_pool.reset();
+    }
+}
+
+pub struct ResourceList {
+    device: Arc<DeviceContext>,
+
+    framebuffers: SmallVec<[types::Framebuffer; 16]>,
+    buffers: SmallVec<[BufferTypeInternal; 16]>,
+    images: SmallVec<[ImageType; 16]>,
+    samplers: SmallVec<[types::Sampler; 16]>,
+    image_views: SmallVec<[types::ImageView; 16]>,
+}
+
+impl ResourceList {
+    fn new(device: Arc<DeviceContext>) -> Self {
+        ResourceList {
+            device,
+            framebuffers: SmallVec::new(),
+            buffers: SmallVec::new(),
+            images: SmallVec::new(),
+            samplers: SmallVec::new(),
+            image_views: SmallVec::new(),
+        }
+    }
+
+    pub fn queue_framebuffer(&mut self, fb: types::Framebuffer) {
+        self.framebuffers.push(fb);
+    }
+
+    pub fn queue_buffer(&mut self, buffer: BufferTypeInternal) {
+        self.buffers.push(buffer);
+    }
+
+    pub fn queue_image(&mut self, image: ImageType) {
+        self.images.push(image);
+    }
+
+    pub fn queue_sampler(&mut self, sampler: types::Sampler) {
+        self.samplers.push(sampler);
+    }
+
+    pub fn queue_image_view(&mut self, image_view: types::ImageView) {
+        self.image_views.push(image_view);
+    }
+
+    fn free_resources(&mut self) {
+        use gfxm::Factory;
+        use std::mem::replace;
+
+        let mut alloc = self.device.allocator();
+
+        let device = &self.device.device;
+
+        let buffers = replace(&mut self.buffers, SmallVec::new());
+        for buffer in buffers {
+            alloc.destroy_buffer(device, buffer);
+        }
+
+        let images = replace(&mut self.images, SmallVec::new());
+        for image in images {
+            alloc.destroy_image(device, image);
+        }
+
+        let samplers = replace(&mut self.samplers, SmallVec::new());
+        for sampler in samplers {
+            device.destroy_sampler(sampler);
+        }
+
+        let image_views = replace(&mut self.image_views, SmallVec::new());
+        for image_view in image_views {
+            device.destroy_image_view(image_view);
+        }
+
+        let framebuffers = replace(&mut self.framebuffers, SmallVec::new());
+        for framebuffer in framebuffers {
+            device.destroy_framebuffer(framebuffer);
+        }
     }
 }


### PR DESCRIPTION
Big PR incoming!

- Queues are now separated, giving the opportunity to have "load balancing" later on.
- `SubmitGroup`s now also have a list of resources to destroy after they are done executing.
- The 2D-squares example now no longer recreates the swapchain on *every frame*, giving huuuuuuge FPS boosts.
