### PR TITLE
improve vertex buffer handling

### DIFF
--- a/examples/2d-squares/main.rs
+++ b/examples/2d-squares/main.rs
@@ -29,7 +29,7 @@ const VERTEX_DATA: [VertexData; 4] = [
     VertexData { pos: [1.0, 1.0] },
 ];
 
-const NUM_THINGS: usize = 10_000;
+const NUM_THINGS: usize = 100_000;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     std::env::set_var("RUST_LOG", "debug");
@@ -56,8 +56,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let vtx_def = {
         let create_info = vertex_attrib::VertexAttribInfo {
-            buffer_stride: ::std::mem::size_of::<VertexData>(),
             buffer_infos: &[vertex_attrib::VertexAttribBufferInfo {
+                stride: ::std::mem::size_of::<VertexData>(),
                 index: 0,
                 elements: &[vertex_attrib::VertexAttribBufferElementInfo {
                     location: 0,
@@ -251,7 +251,7 @@ fn create_graph(
 
     {
         let info = graph::PassInfo::Graphics {
-            vertex_attrib: vec![(0, vertex_attrib)],
+            vertex_attrib: Some(vertex_attrib),
             shaders: graph::Shaders {
                 vertex: graph::ShaderInfo {
                     content: Cow::Borrowed(include_bytes!(concat!(
@@ -297,13 +297,10 @@ fn create_graph(
                 builder.enable();
             }
 
-            fn execute(
-                &self,
-                cmd: &mut graph::CommandBuffer,
-            ) {
+            fn execute(&self, cmd: &mut graph::CommandBuffer) {
                 let things = NUM_THINGS;
 
-                cmd.bind_vertex_array(0, self.buffer);
+                cmd.bind_vertex_buffers(&[(self.buffer, 0)]);
                 cmd.bind_graphics_descriptor_set(1, self.mat_instance);
 
                 cmd.draw(0..4, 0..things as u32);

--- a/examples/2d-squares/shaders/quad.hlsl
+++ b/examples/2d-squares/shaders/quad.hlsl
@@ -39,7 +39,7 @@ VertexOut VertexMain(VertexIn input)
     ret.idx = input.primitive_id;
 
     float2 position;
-    position = input.position * data[ret.idx].size;
+    position = input.position * data[ret.idx].size * 0.25 / 8.0;
     position += data[ret.idx].position;
 
     ret.position = float4(position, 0.0, 1.0);

--- a/examples/two-pass/shaders/read.hlsl
+++ b/examples/two-pass/shaders/read.hlsl
@@ -36,10 +36,7 @@ FragmentOut FragmentMain(VertexOut input)
 
     float2 uv = input.uv;
 
-    // output.color = float4(input.uv, 1.0, 1.0);
-
     output.color = t.Sample(s, uv);
-    output.color.xyz = float3(1.0.xxx) - output.color.xyz;
 
     return output;
 }

--- a/examples/two-pass/shaders/test.hlsl
+++ b/examples/two-pass/shaders/test.hlsl
@@ -48,7 +48,7 @@ FragmentOut FragmentMain(VertexOut input)
 
     output.color = t.Sample(s, input.uv);
 
-    // output.color *= modulate;
+    output.color *= modulate;
 
     return output;
 }

--- a/nitrogen/src/display.rs
+++ b/nitrogen/src/display.rs
@@ -11,8 +11,8 @@ use crate::types::*;
 
 use crate::resources::semaphore_pool::{SemaphoreList, SemaphorePool};
 
-use std;
 use crate::submit_group::ResourceList;
+use std;
 
 pub struct Display {
     pub surface: Surface,

--- a/nitrogen/src/graph/pass.rs
+++ b/nitrogen/src/graph/pass.rs
@@ -19,7 +19,7 @@ pub struct PassId(pub(crate) usize);
 
 pub enum PassInfo {
     Graphics {
-        vertex_attrib: Vec<(usize, VertexAttribHandle)>,
+        vertex_attrib: Option<VertexAttribHandle>,
         shaders: Shaders,
         primitive: Primitive,
         blend_mode: BlendMode,

--- a/nitrogen/src/lib.rs
+++ b/nitrogen/src/lib.rs
@@ -106,7 +106,8 @@ impl Context {
         use std::mem::transmute;
 
         let surface = unsafe {
-            self.instance.create_surface_from_xlib(transmute(display), transmute(window))
+            self.instance
+                .create_surface_from_xlib(transmute(display), transmute(window))
         };
 
         let _ = self

--- a/nitrogen/src/util/submit_group.rs
+++ b/nitrogen/src/util/submit_group.rs
@@ -7,8 +7,8 @@ use gfx::Device;
 use crate::buffer::BufferTypeInternal;
 use crate::image::ImageType;
 
-use crate::*;
 use crate::device::DeviceContext;
+use crate::*;
 
 use crate::resources::semaphore_pool::{SemaphoreList, SemaphorePool};
 


### PR DESCRIPTION
Mutliple vertex buffer descriptions don't actually make sense.
Instead each vertex descriptor has a list of buffer bindings.
The buffers can then be set individually.