### PR TITLE
added support for external resources in graph resolution

### DIFF
--- a/examples/compute/shaders/add.hlsl
+++ b/examples/compute/shaders/add.hlsl
@@ -4,20 +4,14 @@
 
 struct PushData {
     float x;
-    float y;
 };
 
 [[vk::push_constant]]
 ConstantBuffer<PushData> push_data;
 
 
-[[vk::binding(0, 0)]]
-RWStructuredBuffer<float> output;
-
 [[vk::binding(0, 1)]]
-cbuffer {
-    float4 data[];
-}
+RWStructuredBuffer<float> data;
 
 struct DispatchInput {
     uint idx : SV_DispatchThreadID;
@@ -25,5 +19,5 @@ struct DispatchInput {
 
 void ComputeMain(DispatchInput input)
 {
-    output[input.idx] = data[input.idx / 4][input.idx % 4] + push_data.x + push_data.y;
+    data[input.idx] += push_data.x;
 }

--- a/nitrogen/src/graph/builder.rs
+++ b/nitrogen/src/graph/builder.rs
@@ -15,12 +15,14 @@ use std::hash::{Hash, Hasher};
 pub enum ResourceType {
     Image,
     Buffer,
+    Extern,
 }
 
 #[derive(Hash, Debug, Clone)]
 pub(crate) enum ResourceCreateInfo {
     Image(ImageCreateInfo),
     Buffer(BufferCreateInfo),
+    Extern,
 }
 
 #[derive(Hash, Default)]
@@ -152,6 +154,21 @@ impl GraphBuilder {
         self.resource_backbuffer.push(name.into());
     }
 
+    // extern
+
+    pub fn extern_create<T: Into<ResourceName>>(&mut self, name: T) {
+        self.resource_creates
+            .push((name.into(), ResourceCreateInfo::Extern));
+    }
+
+    pub fn extern_move<T0: Into<ResourceName>, T1: Into<ResourceName>>(
+        &mut self,
+        from: T0,
+        to: T1,
+    ) {
+        self.resource_moves.push((to.into(), from.into()));
+    }
+
     // control flow control
 
     pub fn enable(&mut self) {
@@ -249,6 +266,7 @@ impl From<ResourceCreateInfo> for ResourceType {
         match inf {
             ResourceCreateInfo::Image(..) => ResourceType::Image,
             ResourceCreateInfo::Buffer(..) => ResourceType::Buffer,
+            ResourceCreateInfo::Extern => ResourceType::Extern,
         }
     }
 }

--- a/nitrogen/src/graph/execution/derive.rs
+++ b/nitrogen/src/graph/execution/derive.rs
@@ -70,6 +70,10 @@ fn derive_batch(
 
                 usages.image.insert(*create, (usage, format));
             }
+            ResourceCreateInfo::Extern => {
+                // nothing to do here as we are not concerned with how external resources are
+                // constructed
+            }
         }
     }
 

--- a/nitrogen/src/graph/execution/graph.rs
+++ b/nitrogen/src/graph/execution/graph.rs
@@ -30,6 +30,8 @@ pub struct ExecutionGraph {
 
 impl ExecutionGraph {
     pub(crate) fn new(resolved: &GraphResourcesResolved, outputs: &[ResourceName]) -> Self {
+        println!("{:?}", resolved);
+
         let mut pass_execs: Vec<Vec<PassId>> = vec![];
 
         let mut needed_resources = HashSet::with_capacity(outputs.len());

--- a/nitrogen/src/graph/execution/prepare.rs
+++ b/nitrogen/src/graph/execution/prepare.rs
@@ -492,6 +492,10 @@ fn create_resource(
 
             Some(())
         }
+        ResourceCreateInfo::Extern => {
+            // External resources don't really "exist", they are just markers, so nothing to do here
+            Some(())
+        }
     }
 }
 


### PR DESCRIPTION
External resources are just "markers" to add passes to the dependency
chain of the graph.

If a compute pass just modifies an external buffer but does not create
any resources on its own, it could previously not be part of the
execution chain.

Now with external resources new "names" can be created and moved.
That allows side-effect only passes to be part of the cool kids and
be executed as well!