### PR TITLE
update gfx-hal

### DIFF
--- a/examples/2d-squares/main.rs
+++ b/examples/2d-squares/main.rs
@@ -180,8 +180,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     while running {
-        println!("frame");
-
         events_loop.poll_events(|ev| match ev {
             winit::Event::WindowEvent { event, .. } => match event {
                 winit::WindowEvent::CloseRequested => {

--- a/examples/2d-squares/main.rs
+++ b/examples/2d-squares/main.rs
@@ -45,12 +45,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // cool and fun nitrogen stuff
 
-    let mut ctx = Context::new("2d-squares", 1);
+    let mut ctx = unsafe { Context::new("2d-squares", 1) };
     let display = ctx.display_add(&window);
 
-    let mut submit = ctx.create_submit_group();
+    let mut submit = unsafe { ctx.create_submit_group() };
 
-    let material = {
+    let material = unsafe {
         let create_info = material::MaterialCreateInfo {
             parameters: &[
                 // positions
@@ -77,7 +77,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ctx.vertex_attribs_create(&[create_info]).remove(0)
     };
 
-    let vertex_buffer = {
+    let vertex_buffer = unsafe {
         use crate::buffer::BufferUsage;
 
         create_buffer(
@@ -93,9 +93,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let instance_data = create_instance_data(num_squares);
     let instance_vel = create_instance_velocity(num_squares);
 
-    let instance_material = ctx.material_create_instance(&[material]).remove(0).unwrap();
+    let instance_material = unsafe { ctx.material_create_instance(&[material]).remove(0).unwrap() };
 
-    let instance_buffer = {
+    let instance_buffer = unsafe {
         use crate::buffer::BufferUsage;
 
         create_buffer(
@@ -106,7 +106,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
     };
 
-    let velocity_buffer = {
+    let velocity_buffer = unsafe {
         use crate::buffer::BufferUsage;
 
         create_buffer(
@@ -117,7 +117,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
     };
 
-    submit.wait(&mut ctx);
+    unsafe {
+        submit.wait(&mut ctx);
+    }
 
     drop(instance_data);
     drop(instance_vel);
@@ -140,7 +142,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             },
         ];
 
-        ctx.material_write_instance(instance_material, writes);
+        unsafe {
+            ctx.material_write_instance(instance_material, writes);
+        }
     }
 
     let graph = create_graph(
@@ -161,7 +165,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    let mut submits = vec![submit, ctx.create_submit_group()];
+    let mut submits = vec![submit, unsafe { ctx.create_submit_group() }];
 
     let mut frame_num = 0;
     let mut frame_idx = 0;
@@ -176,6 +180,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     while running {
+        println!("frame");
+
         events_loop.poll_events(|ev| match ev {
             winit::Event::WindowEvent { event, .. } => match event {
                 winit::WindowEvent::CloseRequested => {
@@ -202,7 +208,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         {
             let last_idx = frame_idx;
 
-            submits[last_idx].wait(&mut ctx);
+            unsafe {
+                submits[last_idx].wait(&mut ctx);
+            }
         }
 
         // update delta time
@@ -222,7 +230,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         store.insert(Delta(delta));
 
-        {
+        unsafe {
             if resized {
                 submits[frame_idx].display_setup_swapchain(&mut ctx, display);
                 resized = false;
@@ -242,16 +250,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     submits[0].buffer_destroy(&mut ctx, &[vertex_buffer, instance_buffer, velocity_buffer]);
     submits[0].graph_destroy(&mut ctx, &[graph]);
 
+    // wait until all work is done
+    unsafe {
+        ctx.wait_idle();
+    }
+
     for mut submit in submits {
-        submit.wait(&mut ctx);
-        submit.release(&mut ctx);
+        unsafe {
+            submit.wait(&mut ctx);
+            submit.release(&mut ctx);
+        }
     }
 
     ctx.vertex_attribs_destroy(&[vtx_def]);
-    ctx.material_destroy(&[material]);
-    ctx.display_remove(display);
 
-    ctx.release();
+    unsafe {
+        ctx.material_destroy(&[material]);
+        ctx.display_remove(display);
+
+        ctx.release();
+    }
 
     Ok(())
 }
@@ -303,16 +321,18 @@ fn create_graph(
                     }
                 }
 
-                cmd.push_constant::<u32>(0, wide);
-                cmd.push_constant::<u32>(1, NUM_THINGS as u32);
+                unsafe {
+                    cmd.push_constant::<u32>(0, wide);
+                    cmd.push_constant::<u32>(1, NUM_THINGS as u32);
 
-                let Delta(delta) = store.get::<Delta>().unwrap();
+                    let Delta(delta) = store.get::<Delta>().unwrap();
 
-                cmd.push_constant::<f32>(2, *delta as f32);
+                    cmd.push_constant::<f32>(2, *delta as f32);
 
-                cmd.bind_material(1, self.mat_instance);
+                    cmd.bind_material(1, self.mat_instance);
 
-                cmd.dispatch([wide, batch_size, 1]);
+                    cmd.dispatch([wide, batch_size, 1]);
+                }
             }
         }
 
@@ -378,15 +398,17 @@ fn create_graph(
             fn execute(&self, store: &graph::Store, cmd: &mut graph::GraphicsCommandBuffer<'_>) {
                 let things = NUM_THINGS;
 
-                cmd.push_constant::<[f32; 4]>(0, [1.0, 1.0, 1.0, 1.0]);
+                unsafe {
+                    cmd.push_constant::<[f32; 4]>(0, [1.0, 1.0, 1.0, 1.0]);
 
-                let Scale(s) = store.get().unwrap();
-                cmd.push_constant(4, *s);
+                    let Scale(s) = store.get().unwrap();
+                    cmd.push_constant(4, *s);
 
-                cmd.bind_vertex_buffers(&[(self.buffer, 0)]);
-                cmd.bind_material(1, self.mat_instance);
+                    cmd.bind_vertex_buffers(&[(self.buffer, 0)]);
+                    cmd.bind_material(1, self.mat_instance);
 
-                cmd.draw(0..4, 0..things as u32);
+                    cmd.draw(0..4, 0..things as u32);
+                }
             }
         }
 
@@ -448,7 +470,7 @@ fn create_instance_velocity(num: u32) -> Vec<[f32; 2]> {
     result
 }
 
-fn create_buffer<T>(
+unsafe fn create_buffer<T>(
     ctx: &mut Context,
     submit: &mut SubmitGroup,
     data: &[T],

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 nitrogen = { path = "../nitrogen", features = ["winit"] }
-winit = "0.17.2"
+winit = "0.18"
 image = "0.20.0"
 log = "0.4.5"
 rand = "0.6.0"

--- a/examples/common/Cargo.toml
+++ b/examples/common/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 
 [dependencies]
 nitrogen = { path = "../../nitrogen" }
-winit = "0.17.0"
+winit = "0.18"

--- a/examples/common/src/resource.rs
+++ b/examples/common/src/resource.rs
@@ -6,7 +6,7 @@ use nitrogen::buffer::BufferUsage;
 use nitrogen::submit_group::SubmitGroup;
 use nitrogen::*;
 
-fn device_local_buffer_create<T: Sized>(
+unsafe fn device_local_buffer_create<T: Sized>(
     ctx: &mut Context,
     submit: &mut SubmitGroup,
     data: &[T],
@@ -40,7 +40,7 @@ fn device_local_buffer_create<T: Sized>(
     Some(buffer)
 }
 
-pub fn device_local_buffer_vertex<T: Sized>(
+pub unsafe fn device_local_buffer_vertex<T: Sized>(
     ctx: &mut Context,
     submit: &mut SubmitGroup,
     data: &[T],
@@ -50,7 +50,7 @@ pub fn device_local_buffer_vertex<T: Sized>(
     device_local_buffer_create(ctx, submit, data, usage)
 }
 
-pub fn device_local_buffer_index<T: Sized>(
+pub unsafe fn device_local_buffer_index<T: Sized>(
     ctx: &mut Context,
     submit: &mut SubmitGroup,
     data: &[T],
@@ -60,7 +60,7 @@ pub fn device_local_buffer_index<T: Sized>(
     device_local_buffer_create(ctx, submit, data, usage)
 }
 
-pub fn device_local_buffer_storage<T: Sized>(
+pub unsafe fn device_local_buffer_storage<T: Sized>(
     ctx: &mut Context,
     submit: &mut SubmitGroup,
     data: &[T],
@@ -70,7 +70,7 @@ pub fn device_local_buffer_storage<T: Sized>(
     device_local_buffer_create(ctx, submit, data, usage)
 }
 
-pub fn device_local_buffer<T: Sized>(
+pub unsafe fn device_local_buffer<T: Sized>(
     ctx: &mut Context,
     submit: &mut SubmitGroup,
     data: &[T],

--- a/examples/multi-target/main.rs
+++ b/examples/multi-target/main.rs
@@ -33,13 +33,13 @@ fn main() {
     let mut events = winit::EventsLoop::new();
     let window = winit::Window::new(&events).unwrap();
 
-    let mut ntg = nitrogen::Context::new("nitrogen test", 1);
+    let mut ntg = unsafe { nitrogen::Context::new("nitrogen test", 1) };
 
-    let mut submit = ntg.create_submit_group();
+    let mut submit = unsafe { ntg.create_submit_group() };
 
     let display = ntg.display_add(&window);
 
-    let material = {
+    let material = unsafe {
         let create_info = nitrogen::material::MaterialCreateInfo {
             parameters: &[
                 (0, nitrogen::material::MaterialParameterType::SampledImage),
@@ -51,7 +51,8 @@ fn main() {
         ntg.material_create(&[create_info]).remove(0).unwrap()
     };
 
-    let mat_example_instance = { ntg.material_create_instance(&[material]).remove(0).unwrap() };
+    let mat_example_instance =
+        unsafe { ntg.material_create_instance(&[material]).remove(0).unwrap() };
 
     let (image, sampler) = {
         let image_data = include_bytes!("assets/test.png");
@@ -81,11 +82,11 @@ fn main() {
             ..Default::default()
         };
 
-        let img = ntg.image_create(&[create_info]).remove(0).unwrap();
+        let img = unsafe { ntg.image_create(&[create_info]).remove(0).unwrap() };
 
         debug!("width {}, height {}", width, height);
 
-        {
+        unsafe {
             let data = image::ImageUploadInfo {
                 data: &(*image),
                 format: image::ImageFormat::RgbaUnorm,
@@ -101,7 +102,7 @@ fn main() {
 
         drop(image);
 
-        let sampler = {
+        let sampler = unsafe {
             use nitrogen::sampler::{Filter, WrapMode};
 
             let sampler_create = nitrogen::sampler::SamplerCreateInfo {
@@ -117,9 +118,11 @@ fn main() {
         (img, sampler)
     };
 
-    submit.display_setup_swapchain(&mut ntg, display);
+    unsafe {
+        submit.display_setup_swapchain(&mut ntg, display);
+    }
 
-    let buffer_pos = {
+    let buffer_pos = unsafe {
         let create_info = nitrogen::buffer::CpuVisibleCreateInfo {
             size: std::mem::size_of_val(&TRIANGLE_POS) as u64,
             is_transient: false,
@@ -144,7 +147,7 @@ fn main() {
         buffer
     };
 
-    let buffer_uv = {
+    let buffer_uv = unsafe {
         let create_info = nitrogen::buffer::CpuVisibleCreateInfo {
             size: std::mem::size_of_val(&TRIANGLE_UV) as u64,
             is_transient: false,
@@ -219,7 +222,7 @@ fn main() {
         _color: [0.3, 0.5, 1.0, 1.0],
     };
 
-    let uniform_buffer = {
+    let uniform_buffer = unsafe {
         let create_info = nitrogen::buffer::CpuVisibleCreateInfo {
             size: std::mem::size_of::<UniformData>() as u64,
             is_transient: false,
@@ -244,7 +247,7 @@ fn main() {
         buffer
     };
 
-    {
+    unsafe {
         ntg.material_write_instance(
             mat_example_instance,
             &[
@@ -267,7 +270,7 @@ fn main() {
         );
     }
 
-    let mut submits = vec![submit, ntg.create_submit_group()];
+    let mut submits = vec![submit, unsafe { ntg.create_submit_group() }];
 
     let mut frame_num = 0;
     let mut frame_idx = 0;
@@ -302,10 +305,12 @@ fn main() {
         {
             let last_idx = (frame_num + (submits.len() - 1)) % submits.len();
 
-            submits[last_idx].wait(&mut ntg);
+            unsafe {
+                submits[last_idx].wait(&mut ntg);
+            }
         }
 
-        {
+        unsafe {
             if resized {
                 submits[frame_idx].display_setup_swapchain(&mut ntg, display);
                 resized = false;
@@ -328,13 +333,17 @@ fn main() {
     submits[0].graph_destroy(&mut ntg, &[graph]);
 
     for mut submit in submits {
-        submit.wait(&mut ntg);
-        submit.release(&mut ntg);
+        unsafe {
+            submit.wait(&mut ntg);
+            submit.release(&mut ntg);
+        }
     }
 
-    ntg.material_destroy(&[material]);
+    unsafe {
+        ntg.material_destroy(&[material]);
 
-    ntg.release();
+        ntg.release();
+    }
 }
 
 fn setup_graphs(
@@ -401,7 +410,7 @@ fn setup_graphs(
 
                 builder.enable();
             },
-            move |cmd| {
+            move |cmd| unsafe {
                 cmd.bind_vertex_buffers(&[(buffer_pos, 0), (buffer_uv, 0)]);
 
                 cmd.bind_material(1, material_instance);
@@ -448,7 +457,7 @@ fn setup_graphs(
 
                 builder.enable();
             },
-            move |cmd| {
+            move |cmd| unsafe {
                 cmd.bind_vertex_buffers(&[(buffer_pos, 0), (buffer_uv, 0)]);
 
                 cmd.draw(0..4, 0..4);

--- a/examples/opaque-alpha/main.rs
+++ b/examples/opaque-alpha/main.rs
@@ -27,13 +27,19 @@ fn main() {
     std::env::set_var("RUST_LOG", "debug");
     env_logger::init();
 
-    let mut ml = main_loop::MainLoop::new("Nitrogen - Opaque-Alpha example", init_resources);
+    let mut ml =
+        unsafe { main_loop::MainLoop::new("Nitrogen - Opaque-Alpha example", init_resources) };
 
     while ml.running() {
-        ml.iterate();
+        println!("frame start");
+        unsafe {
+            ml.iterate();
+        }
     }
 
-    ml.release();
+    unsafe {
+        ml.release();
+    }
 }
 
 struct Resources {
@@ -181,17 +187,21 @@ fn create_graph(ctx: &mut Context) -> graph::GraphHandle {
                 let size = store.get::<main_loop::CanvasSize>().unwrap();
                 let quads = store.get::<Quads>().unwrap();
 
-                cmd.push_constant::<[f32; 2]>(0, [size.0, size.1]);
+                unsafe {
+                    cmd.push_constant::<[f32; 2]>(0, [size.0, size.1]);
+                }
 
                 for quad in &quads.quads {
-                    cmd.push_constant::<[f32; 2]>(2, quad.pos);
-                    cmd.push_constant::<[f32; 2]>(4, quad.size);
+                    unsafe {
+                        cmd.push_constant::<[f32; 2]>(2, quad.pos);
+                        cmd.push_constant::<[f32; 2]>(4, quad.size);
 
-                    cmd.push_constant::<f32>(6, quad.depth);
+                        cmd.push_constant::<f32>(6, quad.depth);
 
-                    cmd.push_constant::<[f32; 4]>(8, quad.color);
+                        cmd.push_constant::<[f32; 4]>(8, quad.color);
 
-                    cmd.draw(0..4, 0..1);
+                        cmd.draw(0..4, 0..1);
+                    }
                 }
             }
         }
@@ -256,17 +266,21 @@ fn create_graph(ctx: &mut Context) -> graph::GraphHandle {
                 let size = store.get::<main_loop::CanvasSize>().unwrap();
                 let quads = store.get::<QuadsAlpha>().unwrap();
 
-                cmd.push_constant::<[f32; 2]>(0, [size.0, size.1]);
+                unsafe {
+                    cmd.push_constant::<[f32; 2]>(0, [size.0, size.1]);
+                }
 
                 for quad in &quads.quads {
-                    cmd.push_constant::<[f32; 2]>(2, quad.pos);
-                    cmd.push_constant::<[f32; 2]>(4, quad.size);
+                    unsafe {
+                        cmd.push_constant::<[f32; 2]>(2, quad.pos);
+                        cmd.push_constant::<[f32; 2]>(4, quad.size);
 
-                    cmd.push_constant::<f32>(6, quad.depth);
+                        cmd.push_constant::<f32>(6, quad.depth);
 
-                    cmd.push_constant::<[f32; 4]>(8, quad.color);
+                        cmd.push_constant::<[f32; 4]>(8, quad.color);
 
-                    cmd.draw(0..4, 0..1);
+                        cmd.draw(0..4, 0..1);
+                    }
                 }
             }
         }

--- a/nitrogen/Cargo.toml
+++ b/nitrogen/Cargo.toml
@@ -7,11 +7,10 @@ edition = "2018"
 
 
 [features]
-default = ["winit_support"]
-# winit_support = ["back/winit", "winit"]
+default = ["winit_support", "alloc_gfxm"]
 winit_support = ["back/winit", "winit"]
 x11 = []
-
+alloc_gfxm = ["gfx-memory"]
 
 
 [dependencies]
@@ -26,10 +25,10 @@ winit = { version = "0.18", optional = true }
 gfx = { version = "0.1.0", package = "gfx-hal", default-features = false }
 back = { version = "0.1.0", package = "gfx-backend-vulkan", default-features = false }
 
-[dependencies.gfxm]
-package = "gfx-memory"
+[dependencies.gfx-memory]
 git = "https://github.com/gfx-rs/gfx-memory"
 rev = "089f13b60fdb65b4302dbf2850afc83b87119214"
+optional = true
 
 # [dependencies.gfxm]
 # package = "rendy-memory"

--- a/nitrogen/Cargo.toml
+++ b/nitrogen/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [features]
 default = ["winit_support"]
 # winit_support = ["back/winit", "winit"]
-winit_support = ["gfx-backend-vulkan/winit", "winit"]
+winit_support = ["back/winit", "winit"]
 x11 = []
 
 
@@ -21,36 +21,17 @@ failure = "0.1.2"
 failure_derive = "0.1.2"
 bitflags = "1.0.4"
 smallvec = "0.6.5"
-winit = { version = "0.17.2", optional = true }
+winit = { version = "0.18", optional = true }
 
-#
-# [dependencies.gfx]
-# package = "gfx-hal"
-# git = "https://github.com/gfx-rs/gfx"
-# rev = "bd7f058efe78d7626a1cc6fbc0c1d3702fb6d2e7"
-# default-features = false
+gfx = { version = "0.1.0", package = "gfx-hal", default-features = false }
+back = { version = "0.1.0", package = "gfx-backend-vulkan", default-features = false }
 
-# [dependencies.back]
-# package = "gfx-backend-vulkan"
-# git = "https://github.com/gfx-rs/gfx"
-# rev = "bd7f058efe78d7626a1cc6fbc0c1d3702fb6d2e7"
-# default-features = false
+[dependencies.gfxm]
+package = "gfx-memory"
+git = "https://github.com/gfx-rs/gfx-memory"
+rev = "089f13b60fdb65b4302dbf2850afc83b87119214"
 
 # [dependencies.gfxm]
-# package = "gfx-memory"
-# git = "https://github.com/gfx-rs/gfx-memory"
-# rev = "e9bba2f935fe7b6e1fd2ed2862a0c5dcba8af364"
-
-[dependencies.gfx-hal]
-git = "https://github.com/gfx-rs/gfx"
-rev = "bd7f058efe78d7626a1cc6fbc0c1d3702fb6d2e7"
-default-features = false
-
-[dependencies.gfx-backend-vulkan]
-git = "https://github.com/gfx-rs/gfx"
-rev = "bd7f058efe78d7626a1cc6fbc0c1d3702fb6d2e7"
-default-features = false
-
-[dependencies.gfx-memory]
-git = "https://github.com/gfx-rs/gfx-memory"
-rev = "e9bba2f935fe7b6e1fd2ed2862a0c5dcba8af364"
+# package = "rendy-memory"
+# git = "https://github.com/omni-viral/rendy/"
+# rev = "7921de05f2727b0be5fd1fbf8420d527c5bfaee5"

--- a/nitrogen/src/device.rs
+++ b/nitrogen/src/device.rs
@@ -27,7 +27,7 @@ pub(crate) struct DeviceContext {
 }
 
 impl DeviceContext {
-    pub(crate) fn new(instance: &back::Instance) -> Self {
+    pub(crate) unsafe fn new(instance: &back::Instance) -> Self {
         use gfx::PhysicalDevice;
         use std::mem::replace;
 
@@ -163,7 +163,7 @@ impl DeviceContext {
         unsafe { transmute(self.queues[self.compute_queue_idx][0].lock().unwrap()) }
     }
 
-    pub(crate) fn release(self) {
+    pub(crate) unsafe fn release(self) {
         self.memory_allocator
             .into_inner()
             .unwrap()

--- a/nitrogen/src/device.rs
+++ b/nitrogen/src/device.rs
@@ -5,8 +5,8 @@
 use gfx::Device;
 use gfx::Instance;
 
-use crate::util::allocator::{Allocator, DefaultAlloc};
 use crate::types;
+use crate::util::allocator::{Allocator, DefaultAlloc};
 
 use smallvec::SmallVec;
 
@@ -33,7 +33,6 @@ impl DeviceContext {
 
         // TODO select best fitting adapter
         let adapter = adapters.remove(0);
-
 
         let (device, mut queue_groups, graphics_idx, compute_idx) = {
             use gfx::QueueFamily;

--- a/nitrogen/src/display.rs
+++ b/nitrogen/src/display.rs
@@ -84,8 +84,6 @@ impl Display {
         let mut config =
             gfx::SwapchainConfig::from_caps(&surface_capability, format, default_extent);
 
-        println!("{:?}", surface_capability);
-        println!("{:?}", config);
         config.image_usage |= gfx::image::Usage::TRANSFER_DST;
         config.image_layers = 1;
 
@@ -192,8 +190,8 @@ impl Display {
                     use gfx::pso::PipelineStage;
 
                     let src_barrier = gfx::memory::Barrier::Image {
-                        states: (Access::empty(), Layout::Undefined)
-                            ..(Access::TRANSFER_WRITE, Layout::TransferSrcOptimal),
+                        states: (Access::empty(), Layout::General)
+                            ..(Access::TRANSFER_READ, Layout::TransferSrcOptimal),
                         target: src_image,
                         families: None,
                         range: subres_range.clone(),
@@ -264,14 +262,14 @@ impl Display {
                     use gfx::pso::PipelineStage;
 
                     let src_barrier = gfx::memory::Barrier::Image {
-                        states: (Access::TRANSFER_WRITE, Layout::TransferSrcOptimal)
+                        states: (Access::empty(), Layout::TransferSrcOptimal)
                             ..(Access::empty(), Layout::General),
                         target: src_image,
                         families: None,
                         range: subres_range.clone(),
                     };
                     let dst_barrier = gfx::memory::Barrier::Image {
-                        states: (Access::TRANSFER_WRITE, Layout::TransferDstOptimal)
+                        states: (Access::empty(), Layout::TransferDstOptimal)
                             ..(Access::empty(), Layout::Present),
                         target: dst_image,
                         families: None,

--- a/nitrogen/src/display.rs
+++ b/nitrogen/src/display.rs
@@ -83,6 +83,9 @@ impl Display {
 
         let mut config =
             gfx::SwapchainConfig::from_caps(&surface_capability, format, default_extent);
+
+        println!("{:?}", surface_capability);
+        println!("{:?}", config);
         config.image_usage |= gfx::image::Usage::TRANSFER_DST;
         config.image_layers = 1;
 

--- a/nitrogen/src/display.rs
+++ b/nitrogen/src/display.rs
@@ -9,6 +9,7 @@ use crate::image;
 
 use crate::types::*;
 
+use crate::resources::command_pool::CommandPoolGraphics;
 use crate::resources::semaphore_pool::{SemaphoreList, SemaphorePool};
 
 use crate::submit_group::ResourceList;
@@ -30,7 +31,7 @@ impl Display {
     pub(crate) fn new(surface: Surface, device: &DeviceContext) -> Self {
         use gfx::Surface;
 
-        let (_, formats, _) = surface.compatibility(&device.adapter.physical_device);
+        let (_, formats, _, _) = surface.compatibility(&device.adapter.physical_device);
 
         let format = formats.unwrap().remove(0);
 
@@ -46,7 +47,11 @@ impl Display {
     /// Setup the swapchain and associated framebuffers/images.
     ///
     /// Destroys the old swapchain, so the caller needs to make sure that it's no longer in use
-    pub(crate) fn setup_swapchain(&mut self, device: &DeviceContext, res_list: &mut ResourceList) {
+    pub(crate) unsafe fn setup_swapchain(
+        &mut self,
+        device: &DeviceContext,
+        res_list: &mut ResourceList,
+    ) {
         use gfx::Surface;
 
         {
@@ -66,12 +71,18 @@ impl Display {
             }
         }
 
-        let (surface_capability, _, _) =
+        let (surface_capability, _, _, _) =
             self.surface.compatibility(&device.adapter.physical_device);
 
         let format = self.display_format;
 
-        let mut config = gfx::SwapchainConfig::from_caps(&surface_capability, format);
+        let default_extent = gfx::window::Extent2D {
+            width: 100,
+            height: 100,
+        };
+
+        let mut config =
+            gfx::SwapchainConfig::from_caps(&surface_capability, format, default_extent);
         config.image_usage |= gfx::image::Usage::TRANSFER_DST;
         config.image_layers = 1;
 
@@ -128,12 +139,12 @@ impl Display {
     /// Present an image to the screen.
     ///
     /// The image has to be the same size as the swapchain images in order to preserve aspect ratio.
-    pub(crate) fn present<'a>(
+    pub(crate) unsafe fn present<'a>(
         &'a mut self,
         device: &DeviceContext,
         sem_pool: &mut SemaphorePool,
         sem_list: &mut SemaphoreList,
-        command_pool: &mut CommandPool<gfx::Graphics>,
+        command_pool: &CommandPoolGraphics,
         image_storage: &image::ImageStorage,
         image: image::ImageHandle,
     ) -> bool {
@@ -160,7 +171,7 @@ impl Display {
             sem_list.add_prev_semaphore(sem_acquire);
 
             let submit = {
-                let mut cmd = command_pool.acquire_command_buffer(false);
+                let mut cmd = command_pool.alloc();
 
                 let src_image = image.image.raw();
                 let dst_image = &self.images[index as usize].0;
@@ -181,12 +192,14 @@ impl Display {
                         states: (Access::empty(), Layout::Undefined)
                             ..(Access::TRANSFER_WRITE, Layout::TransferSrcOptimal),
                         target: src_image,
+                        families: None,
                         range: subres_range.clone(),
                     };
                     let dst_barrier = gfx::memory::Barrier::Image {
                         states: (Access::empty(), Layout::Undefined)
                             ..(Access::TRANSFER_WRITE, Layout::TransferDstOptimal),
                         target: dst_image,
+                        families: None,
                         range: subres_range.clone(),
                     };
 
@@ -251,12 +264,14 @@ impl Display {
                         states: (Access::TRANSFER_WRITE, Layout::TransferSrcOptimal)
                             ..(Access::empty(), Layout::General),
                         target: src_image,
+                        families: None,
                         range: subres_range.clone(),
                     };
                     let dst_barrier = gfx::memory::Barrier::Image {
                         states: (Access::TRANSFER_WRITE, Layout::TransferDstOptimal)
                             ..(Access::empty(), Layout::Present),
                         target: dst_image,
+                        families: None,
                         range: subres_range.clone(),
                     };
 
@@ -267,7 +282,9 @@ impl Display {
                     );
                 }
 
-                cmd.finish()
+                cmd.finish();
+
+                cmd
             };
 
             let sem_blit = sem_pool.alloc();
@@ -278,20 +295,18 @@ impl Display {
             let mut queue = device.graphics_queue();
 
             {
-                let submission = gfx::Submission::new()
-                    .wait_on(
-                        sem_pool
-                            .list_prev_sems(sem_list)
-                            .map(|sem| (sem, pso::PipelineStage::BOTTOM_OF_PIPE)),
-                    )
-                    .signal(&[&*sem_present])
-                    .signal(sem_pool.list_next_sems(sem_list))
-                    .submit(Some(submit));
+                let submission = gfx::Submission {
+                    command_buffers: Some(&*submit),
+                    wait_semaphores: sem_pool
+                        .list_prev_sems(sem_list)
+                        .map(|sem| (sem, pso::PipelineStage::BOTTOM_OF_PIPE)),
+                    signal_semaphores: sem_pool.list_next_sems(sem_list).chain(Some(&*sem_present)),
+                };
                 queue.submit(submission, None);
             }
 
             let res = swapchain
-                .present(&mut *queue, index, std::iter::once(sem_present))
+                .present(&mut *queue, index, std::iter::once(&*sem_present))
                 .is_ok();
 
             sem_list.advance();
@@ -303,7 +318,7 @@ impl Display {
     }
 
     /// Release the display context, destroys all associated graphics resources.
-    pub(crate) fn release(self, device: &DeviceContext) {
+    pub(crate) unsafe fn release(self, device: &DeviceContext) {
         for (_, image_view) in self.images {
             device.device.destroy_image_view(image_view);
         }

--- a/nitrogen/src/graph/command.rs
+++ b/nitrogen/src/graph/command.rs
@@ -5,7 +5,6 @@
 use std::ops::Range;
 
 use gfx;
-use gfx::command;
 
 use crate::types;
 

--- a/nitrogen/src/graph/command.rs
+++ b/nitrogen/src/graph/command.rs
@@ -25,19 +25,23 @@ pub(crate) struct ReadStorages<'a> {
 }
 
 pub struct GraphicsCommandBuffer<'a> {
-    pub(crate) encoder:
-        gfx::command::RenderPassInlineEncoder<'a, back::Backend, gfx::command::Primary>,
+    pub(crate) encoder: gfx::command::RenderPassInlineEncoder<'a, back::Backend>,
     pub(crate) storages: &'a ReadStorages<'a>,
 
     pub(crate) pipeline_layout: &'a types::PipelineLayout,
 }
 
 impl<'a> GraphicsCommandBuffer<'a> {
-    pub fn draw(&mut self, vertices: Range<u32>, instances: Range<u32>) {
+    pub unsafe fn draw(&mut self, vertices: Range<u32>, instances: Range<u32>) {
         self.encoder.draw(vertices, instances);
     }
 
-    pub fn draw_indexed(&mut self, indices: Range<u32>, base_vertex: i32, instances: Range<u32>) {
+    pub unsafe fn draw_indexed(
+        &mut self,
+        indices: Range<u32>,
+        base_vertex: i32,
+        instances: Range<u32>,
+    ) {
         self.encoder.draw_indexed(indices, base_vertex, instances);
     }
 
@@ -45,7 +49,7 @@ impl<'a> GraphicsCommandBuffer<'a> {
     /// The provided pairs of buffer and `usize` represent the buffer to bind
     /// and the **offset into the buffer**.
     /// The first pair will be bound to vertex buffer 0, the second to 1, etc...
-    pub fn bind_vertex_buffers<T, I>(&mut self, buffers: T)
+    pub unsafe fn bind_vertex_buffers<T, I>(&mut self, buffers: T)
     where
         T: IntoIterator<Item = I>,
         T::Item: std::borrow::Borrow<(BufferHandle, usize)>,
@@ -63,7 +67,12 @@ impl<'a> GraphicsCommandBuffer<'a> {
         self.encoder.bind_vertex_buffers(0, bufs);
     }
 
-    pub fn bind_index_buffer(&mut self, buffer: BufferHandle, offset: u64, index_type: IndexType) {
+    pub unsafe fn bind_index_buffer(
+        &mut self,
+        buffer: BufferHandle,
+        offset: u64,
+        index_type: IndexType,
+    ) {
         let stores = self.storages.clone();
 
         let buffer_raw = stores.buffer.raw(buffer).map(|buf| buf.buffer.raw());
@@ -84,7 +93,7 @@ impl<'a> GraphicsCommandBuffer<'a> {
             });
     }
 
-    pub fn bind_material(
+    pub unsafe fn bind_material(
         &mut self,
         binding: usize,
         material: MaterialInstanceHandle,
@@ -102,7 +111,7 @@ impl<'a> GraphicsCommandBuffer<'a> {
         Some(())
     }
 
-    pub fn push_constant_raw(&mut self, offset: u32, data: &[u32]) {
+    pub unsafe fn push_constant_raw(&mut self, offset: u32, data: &[u32]) {
         self.encoder.push_graphics_constants(
             self.pipeline_layout,
             gfx::pso::ShaderStageFlags::ALL,
@@ -111,35 +120,32 @@ impl<'a> GraphicsCommandBuffer<'a> {
         )
     }
 
-    pub fn push_constant<T: Sized>(&mut self, offset: u32, data: T) {
+    pub unsafe fn push_constant<T: Sized>(&mut self, offset: u32, data: T) {
         use smallvec::SmallVec;
         let mut buf = SmallVec::<[u8; 1024]>::new();
 
-        unsafe {
-            buf.set_len(1024);
-        }
+        buf.set_len(1024);
 
         {
-            let u32_slice = unsafe { data_to_u32_slice(data, &mut buf[..]) };
+            let u32_slice = data_to_u32_slice(data, &mut buf[..]);
             self.push_constant_raw(offset, u32_slice);
         }
     }
 }
 
 pub struct ComputeCommandBuffer<'a> {
-    pub(crate) buf:
-        command::CommandBuffer<'a, back::Backend, gfx::Compute, command::OneShot, command::Primary>,
+    pub(crate) buf: &'a mut crate::resources::command_pool::CmdBufType<gfx::Compute>,
     pub(crate) storages: &'a ReadStorages<'a>,
 
     pub(crate) pipeline_layout: &'a types::PipelineLayout,
 }
 
 impl<'a> ComputeCommandBuffer<'a> {
-    pub fn dispatch(&mut self, workgroup_count: [u32; 3]) {
+    pub unsafe fn dispatch(&mut self, workgroup_count: [u32; 3]) {
         self.buf.dispatch(workgroup_count)
     }
 
-    pub fn bind_material(
+    pub unsafe fn bind_material(
         &mut self,
         binding: usize,
         material: MaterialInstanceHandle,
@@ -157,21 +163,19 @@ impl<'a> ComputeCommandBuffer<'a> {
         Some(())
     }
 
-    pub fn push_constant_raw(&mut self, offset: u32, data: &[u32]) {
+    pub unsafe fn push_constant_raw(&mut self, offset: u32, data: &[u32]) {
         self.buf
             .push_compute_constants(self.pipeline_layout, offset, data);
     }
 
-    pub fn push_constant<T: Sized>(&mut self, offset: u32, data: T) {
+    pub unsafe fn push_constant<T: Sized>(&mut self, offset: u32, data: T) {
         use smallvec::SmallVec;
         let mut buf = SmallVec::<[u8; 1024]>::new();
 
-        unsafe {
-            buf.set_len(1024);
-        }
+        buf.set_len(1024);
 
         {
-            let u32_slice = unsafe { data_to_u32_slice(data, &mut buf[..]) };
+            let u32_slice = data_to_u32_slice(data, &mut buf[..]);
 
             self.push_constant_raw(offset, u32_slice);
         }

--- a/nitrogen/src/graph/execution/execute.rs
+++ b/nitrogen/src/graph/execution/execute.rs
@@ -12,8 +12,6 @@ use crate::graph::{
     ResourceWriteType,
 };
 
-use crate::types::CommandPool;
-
 use gfx::Device;
 
 use smallvec::SmallVec;

--- a/nitrogen/src/graph/execution/prepare.rs
+++ b/nitrogen/src/graph/execution/prepare.rs
@@ -23,7 +23,7 @@ use smallvec::SmallVec;
 use crate::resources::material::MaterialStorage;
 use std::collections::BTreeMap;
 
-pub(crate) fn prepare_base(
+pub(crate) unsafe fn prepare_base(
     device: &DeviceContext,
     storages: &mut Storages,
     exec: &ExecutionGraph,
@@ -43,7 +43,7 @@ pub(crate) fn prepare_base(
     res
 }
 
-pub(crate) fn prepare_pass_base(
+pub(crate) unsafe fn prepare_pass_base(
     device: &DeviceContext,
     storages: &mut Storages,
     resolved: &GraphResourcesResolved,
@@ -81,7 +81,7 @@ pub(crate) fn prepare_pass_base(
     }
 }
 
-pub(crate) fn prepare(
+pub(crate) unsafe fn prepare(
     usages: &ResourceUsages,
     base: &GraphBaseResources,
     device: &DeviceContext,
@@ -118,7 +118,7 @@ pub(crate) fn prepare(
     res
 }
 
-pub(crate) fn prepare_pass(
+pub(crate) unsafe fn prepare_pass(
     base: &GraphBaseResources,
     device: &DeviceContext,
     storages: &mut Storages,
@@ -212,7 +212,7 @@ pub(crate) fn prepare_pass(
     }
 }
 
-fn create_render_pass(
+unsafe fn create_render_pass(
     device: &DeviceContext,
     storages: &mut Storages,
     resolved_graph: &GraphResourcesResolved,
@@ -403,7 +403,7 @@ fn create_render_pass(
         .ok()
 }
 
-fn create_pipeline_compute(
+unsafe fn create_pipeline_compute(
     device: &DeviceContext,
     storages: &mut Storages,
     resolved: &GraphResourcesResolved,
@@ -449,7 +449,7 @@ fn create_pipeline_compute(
     pipeline_handle.map(move |handle| (handle, pass_stuff.0, pass_stuff.1, pass_stuff.2))
 }
 
-fn create_pipeline_graphics(
+unsafe fn create_pipeline_graphics(
     device: &DeviceContext,
     storages: &mut Storages,
     resolved_graph: &GraphResourcesResolved,
@@ -518,7 +518,7 @@ fn create_pipeline_graphics(
     pipeline_handle.map(move |handle| (handle, pass_stuff.0, pass_stuff.1, pass_stuff.2))
 }
 
-fn create_resource(
+unsafe fn create_resource(
     usages: &ResourceUsages,
     device: &DeviceContext,
     context: &ExecutionContext,
@@ -635,7 +635,7 @@ fn create_resource(
     }
 }
 
-fn create_pipeline_base<'a>(
+unsafe fn create_pipeline_base<'a>(
     device: &DeviceContext,
     resolved: &GraphResourcesResolved,
     material_storage: &'a MaterialStorage,

--- a/nitrogen/src/graph/mod.rs
+++ b/nitrogen/src/graph/mod.rs
@@ -12,6 +12,7 @@ use smallvec::SmallVec;
 use crate::device::DeviceContext;
 use crate::resources::{
     buffer::BufferStorage,
+    command_pool::{CommandPoolCompute, CommandPoolGraphics},
     image::ImageStorage,
     material::MaterialStorage,
     pipeline::PipelineStorage,
@@ -251,13 +252,13 @@ impl GraphStorage {
         }
     }
 
-    pub(crate) fn execute(
+    pub(crate) unsafe fn execute(
         &mut self,
         device: &DeviceContext,
         sem_pool: &mut SemaphorePool,
         sem_list: &mut SemaphoreList,
-        cmd_pool_gfx: &mut CommandPool<gfx::Graphics>,
-        cmd_pool_cmpt: &mut CommandPool<gfx::Compute>,
+        cmd_pool_gfx: &CommandPoolGraphics,
+        cmd_pool_cmpt: &CommandPoolCompute,
         res_list: &mut ResourceList,
         storages: &mut Storages,
         store: &Store,

--- a/nitrogen/src/graph/mod.rs
+++ b/nitrogen/src/graph/mod.rs
@@ -22,8 +22,6 @@ use crate::resources::{
     vertex_attrib::VertexAttribStorage,
 };
 
-use crate::types::CommandPool;
-
 pub mod pass;
 pub use self::pass::*;
 

--- a/nitrogen/src/resources/buffer.rs
+++ b/nitrogen/src/resources/buffer.rs
@@ -11,9 +11,8 @@ use std::collections::BTreeSet;
 
 use crate::device::DeviceContext;
 
+use crate::util::allocator::{Allocator, AllocatorError, Buffer as AllocBuffer, BufferRequest};
 use crate::util::storage::{Handle, Storage};
-use crate::util::allocator::{Allocator, DefaultAlloc, AllocatorError, BufferRequest, Buffer as AllocBuffer};
-
 
 use smallvec::SmallVec;
 
@@ -21,7 +20,6 @@ use crate::resources::command_pool::CommandPoolTransfer;
 use crate::resources::semaphore_pool::SemaphoreList;
 use crate::resources::semaphore_pool::SemaphorePool;
 use crate::submit_group::ResourceList;
-use crate::types::CommandPool;
 
 pub(crate) type BufferTypeInternal = AllocBuffer;
 
@@ -200,16 +198,13 @@ impl BufferStorage {
                 size: create_info.size,
             };
 
-
-            let raw_buffer =
-                match allocator.create_buffer(&device.device, req)
-                {
-                    Ok(buf) => buf,
-                    Err(err) => {
-                        results.push(Err(err.into()));
-                        continue;
-                    }
-                };
+            let raw_buffer = match allocator.create_buffer(&device.device, req) {
+                Ok(buf) => buf,
+                Err(err) => {
+                    results.push(Err(err.into()));
+                    continue;
+                }
+            };
 
             let buffer = Buffer {
                 size: create_info.size,
@@ -320,15 +315,13 @@ impl BufferStorage {
                 size: create_info.size,
             };
 
-            let raw_buffer =
-                match allocator.create_buffer(&device.device, req)
-                {
-                    Ok(buf) => buf,
-                    Err(err) => {
-                        results.push(Err(err.into()));
-                        continue;
-                    }
-                };
+            let raw_buffer = match allocator.create_buffer(&device.device, req) {
+                Ok(buf) => buf,
+                Err(err) => {
+                    results.push(Err(err.into()));
+                    continue;
+                }
+            };
 
             let buffer = Buffer {
                 size: create_info.size,
@@ -405,10 +398,7 @@ impl BufferStorage {
                 size: u8_slice.len() as u64,
             };
 
-            let staging_res = alloc.create_buffer(
-                &device.device,
-                req,
-            );
+            let staging_res = alloc.create_buffer(&device.device, req);
 
             let staging_buffer = match staging_res {
                 Err(err) => {
@@ -535,8 +525,8 @@ unsafe fn read_data_from_buffer(
     offset: u64,
     data: &mut [u8],
 ) -> Result<()> {
-    use gfx::Device;
     use crate::util::allocator::Block;
+    use gfx::Device;
 
     let offset = offset as usize;
 

--- a/nitrogen/src/resources/command_pool.rs
+++ b/nitrogen/src/resources/command_pool.rs
@@ -23,8 +23,6 @@ where
     C: gfx::queue::capability::Capability,
 {
     fn new_elem(&mut self) -> CmdBufType<C> {
-        println!("new");
-
         let mut buf = self.pool.acquire_command_buffer::<gfx::command::OneShot>();
         unsafe {
             buf.begin();
@@ -33,7 +31,6 @@ where
     }
 
     fn reset_elem(&mut self, elem: &mut CmdBufType<C>) {
-        println!("reset/begin()");
         unsafe {
             elem.begin();
         }

--- a/nitrogen/src/resources/command_pool.rs
+++ b/nitrogen/src/resources/command_pool.rs
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::device::DeviceContext;
+use crate::types;
+use crate::util::pool::{Pool, PoolElem, PoolImpl};
+
+use gfx::command::Primary;
+use gfx::command::Shot;
+use gfx::queue::capability::Capability;
+
+pub(crate) type CmdBufType<C> =
+    gfx::command::CommandBuffer<back::Backend, C, gfx::command::OneShot, Primary>;
+pub(crate) type CommandBuffer<'a, C> = PoolElem<'a, CommandPoolImpl<C>, CmdBufType<C>>;
+
+pub(crate) struct CommandPoolImpl<T: gfx::queue::capability::Capability> {
+    pub(crate) pool: gfx::pool::CommandPool<back::Backend, T>,
+}
+
+impl<C> PoolImpl<CmdBufType<C>> for CommandPoolImpl<C>
+where
+    C: gfx::queue::capability::Capability,
+{
+    fn new_elem(&mut self) -> CmdBufType<C> {
+        println!("new");
+
+        let mut buf = self.pool.acquire_command_buffer::<gfx::command::OneShot>();
+        unsafe {
+            buf.begin();
+        }
+        buf
+    }
+
+    fn reset_elem(&mut self, elem: &mut CmdBufType<C>) {
+        println!("reset/begin()");
+        unsafe {
+            elem.begin();
+        }
+    }
+
+    fn free_elem(&mut self, elem: CmdBufType<C>) {
+        unsafe {
+            self.pool.free(Some(elem));
+        }
+    }
+
+    fn free_on_drop() -> bool {
+        false
+    }
+}
+
+pub(crate) struct CommandPool<C: Capability>(pub(crate) Pool<CmdBufType<C>, CommandPoolImpl<C>>);
+
+pub(crate) type CommandPoolGraphics = CommandPool<gfx::Graphics>;
+pub(crate) type CommandPoolCompute = CommandPool<gfx::Compute>;
+pub(crate) type CommandPoolTransfer = CommandPool<gfx::Transfer>;
+
+impl<C: Capability> CommandPool<C> {
+    pub(crate) fn new(pool: gfx::pool::CommandPool<back::Backend, C>) -> Self {
+        CommandPool(Pool::new(CommandPoolImpl { pool }))
+    }
+
+    pub(crate) unsafe fn alloc(&self) -> CommandBuffer<'_, C> {
+        self.0.alloc()
+    }
+
+    pub(crate) unsafe fn reset(&mut self) {
+        // reset the command pool instead of resetting individual elements
+        self.0.impl_ref_mut().pool.reset();
+        self.clear();
+    }
+
+    pub(crate) unsafe fn clear(&mut self) {
+        self.0.clear()
+    }
+}

--- a/nitrogen/src/resources/command_pool.rs
+++ b/nitrogen/src/resources/command_pool.rs
@@ -2,12 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::device::DeviceContext;
-use crate::types;
 use crate::util::pool::{Pool, PoolElem, PoolImpl};
 
 use gfx::command::Primary;
-use gfx::command::Shot;
 use gfx::queue::capability::Capability;
 
 pub(crate) type CmdBufType<C> =

--- a/nitrogen/src/resources/image.rs
+++ b/nitrogen/src/resources/image.rs
@@ -15,22 +15,17 @@ use std::hash::{Hash, Hasher};
 use smallvec::smallvec;
 use smallvec::SmallVec;
 
+use crate::util::allocator::{
+    Allocator, AllocatorError, BufferRequest, Image as AllocImage, ImageRequest,
+};
 use crate::util::storage::{Handle, Storage};
 use crate::util::transfer;
-use crate::util::allocator::{
-    Allocator,
-    AllocatorError,
-    Image as AllocImage,
-    ImageRequest,
-    BufferRequest,
-};
 
 use crate::device::DeviceContext;
 use crate::resources::command_pool::CommandPoolTransfer;
 use crate::resources::semaphore_pool::SemaphoreList;
 use crate::resources::semaphore_pool::SemaphorePool;
 use crate::submit_group::ResourceList;
-use crate::types::CommandPool;
 
 #[derive(Copy, Clone, Debug)]
 pub enum ImageDimension {
@@ -383,10 +378,7 @@ impl ImageStorage {
                     view_caps: image::ViewCapabilities::empty(),
                 };
 
-                let image = allocator.create_image(
-                    &device.device,
-                    req,
-                );
+                let image = allocator.create_image(&device.device, req);
 
                 match image {
                     Err(e) => {
@@ -554,10 +546,7 @@ impl ImageStorage {
                     size: upload_size,
                 };
 
-                let staging_buffer = match allocator.create_buffer(
-                    &device.device,
-                    buf_req,
-                ) {
+                let staging_buffer = match allocator.create_buffer(&device.device, buf_req) {
                     Err(e) => {
                         results[idx] = Err(e.into());
                         return None;

--- a/nitrogen/src/resources/image.rs
+++ b/nitrogen/src/resources/image.rs
@@ -21,6 +21,7 @@ use crate::util::storage::{Handle, Storage};
 use crate::util::transfer;
 
 use crate::device::DeviceContext;
+use crate::resources::command_pool::CommandPoolTransfer;
 use crate::resources::semaphore_pool::SemaphoreList;
 use crate::resources::semaphore_pool::SemaphorePool;
 use crate::submit_group::ResourceList;
@@ -305,7 +306,7 @@ impl ImageStorage {
         }
     }
 
-    pub(crate) fn release(self, device: &DeviceContext) {
+    pub(crate) unsafe fn release(self, device: &DeviceContext) {
         let mut alloc = device.allocator();
 
         for (_, image) in self.storage.into_iter() {
@@ -314,7 +315,7 @@ impl ImageStorage {
         }
     }
 
-    pub(crate) fn create<T: Into<gfx::image::Usage> + Clone>(
+    pub(crate) unsafe fn create<T: Into<gfx::image::Usage> + Clone>(
         &mut self,
         device: &DeviceContext,
         create_infos: &[ImageCreateInfo<T>],
@@ -431,12 +432,12 @@ impl ImageStorage {
         result
     }
 
-    pub(crate) fn upload_data(
+    pub(crate) unsafe fn upload_data(
         &self,
         device: &DeviceContext,
         sem_pool: &SemaphorePool,
         sem_list: &mut SemaphoreList,
-        cmd_pool: &mut CommandPool<gfx::Transfer>,
+        cmd_pool: &CommandPoolTransfer,
         res_list: &mut ResourceList,
         images: &[(ImageHandle, ImageUploadInfo)],
     ) -> SmallVec<[Result<()>; 16]> {

--- a/nitrogen/src/resources/material.rs
+++ b/nitrogen/src/resources/material.rs
@@ -113,7 +113,7 @@ impl MaterialStorage {
         }
     }
 
-    pub(crate) fn create(
+    pub(crate) unsafe fn create(
         &mut self,
         device: &DeviceContext,
         create_infos: &[MaterialCreateInfo],
@@ -165,7 +165,7 @@ impl MaterialStorage {
         results
     }
 
-    pub(crate) fn destroy(&mut self, device: &DeviceContext, materials: &[MaterialHandle]) {
+    pub(crate) unsafe fn destroy(&mut self, device: &DeviceContext, materials: &[MaterialHandle]) {
         for handle in materials {
             if let Some(mat) = self.storage.remove(*handle) {
                 mat.release(device);
@@ -177,7 +177,7 @@ impl MaterialStorage {
         self.storage.get(material)
     }
 
-    pub(crate) fn create_instances(
+    pub(crate) unsafe fn create_instances(
         &mut self,
         device: &DeviceContext,
         materials: &[MaterialHandle],
@@ -212,7 +212,7 @@ impl MaterialStorage {
         results
     }
 
-    pub(crate) fn write_instance<I>(
+    pub(crate) unsafe fn write_instance<I>(
         &self,
         device: &DeviceContext,
         sampler_storage: &SamplerStorage,
@@ -262,7 +262,7 @@ impl MaterialStorage {
         Some(())
     }
 
-    pub(crate) fn destroy_instances(&mut self, instances: &[MaterialInstanceHandle]) {
+    pub(crate) unsafe fn destroy_instances(&mut self, instances: &[MaterialInstanceHandle]) {
         for (mat_handle, inst) in instances {
             let mat = match self.storage.get_mut(*mat_handle) {
                 Some(mat) => mat,
@@ -273,7 +273,7 @@ impl MaterialStorage {
         }
     }
 
-    pub(crate) fn release(self, device: &DeviceContext) {
+    pub(crate) unsafe fn release(self, device: &DeviceContext) {
         for (_id, mat) in self.storage {
             mat.release(device);
         }
@@ -291,7 +291,7 @@ impl Material {
         None
     }
 
-    fn create_new_pool(&mut self, device: &DeviceContext) -> usize {
+    unsafe fn create_new_pool(&mut self, device: &DeviceContext) -> usize {
         use gfx::Device;
 
         let descriptors = self
@@ -316,7 +316,7 @@ impl Material {
         new_pool_idx
     }
 
-    fn release(self, device: &DeviceContext) {
+    unsafe fn release(self, device: &DeviceContext) {
         use gfx::Device;
 
         for pool in self.pools {
@@ -328,7 +328,7 @@ impl Material {
             .destroy_descriptor_set_layout(self.desc_set_layout);
     }
 
-    fn create_instance(
+    unsafe fn create_instance(
         &mut self,
         device: &DeviceContext,
     ) -> Result<Handle<MaterialInstance>, gfx::pso::AllocationError> {
@@ -351,7 +351,7 @@ impl Material {
         Ok(self.instances.insert(instance))
     }
 
-    fn free_instance(&mut self, handle: Handle<MaterialInstance>) -> Option<()> {
+    unsafe fn free_instance(&mut self, handle: Handle<MaterialInstance>) -> Option<()> {
         use gfx::pso::DescriptorPool;
         use std;
 

--- a/nitrogen/src/resources/mod.rs
+++ b/nitrogen/src/resources/mod.rs
@@ -5,6 +5,7 @@
 pub use super::*;
 
 pub mod buffer;
+pub(crate) mod command_pool;
 pub mod image;
 pub mod material;
 pub(crate) mod pipeline;

--- a/nitrogen/src/resources/pipeline.rs
+++ b/nitrogen/src/resources/pipeline.rs
@@ -118,7 +118,7 @@ impl PipelineStorage {
         }
     }
 
-    pub(crate) fn create_graphics_pipelines(
+    pub(crate) unsafe fn create_graphics_pipelines(
         &mut self,
         device: &DeviceContext,
         render_pass_storage: &RenderPassStorage,
@@ -141,7 +141,7 @@ impl PipelineStorage {
     }
 
     // I'm sorry Mike Acton
-    fn create_graphics_pipeline(
+    unsafe fn create_graphics_pipeline(
         &mut self,
         device: &DeviceContext,
         render_pass_storage: &RenderPassStorage,
@@ -316,7 +316,7 @@ impl PipelineStorage {
         Ok(handle)
     }
 
-    pub(crate) fn create_compute_pipelines(
+    pub(crate) unsafe fn create_compute_pipelines(
         &mut self,
         device: &DeviceContext,
         create_infos: &[ComputePipelineCreateInfo],
@@ -327,7 +327,7 @@ impl PipelineStorage {
             .collect()
     }
 
-    pub(crate) fn create_compute_pipeline(
+    pub(crate) unsafe fn create_compute_pipeline(
         &mut self,
         device: &DeviceContext,
         create_info: &ComputePipelineCreateInfo,

--- a/nitrogen/src/resources/render_pass.rs
+++ b/nitrogen/src/resources/render_pass.rs
@@ -46,7 +46,7 @@ impl RenderPassStorage {
         }
     }
 
-    pub(crate) fn create(
+    pub(crate) unsafe fn create(
         &mut self,
         device: &DeviceContext,
         create_infos: &[RenderPassCreateInfo],

--- a/nitrogen/src/resources/sampler.rs
+++ b/nitrogen/src/resources/sampler.rs
@@ -92,7 +92,7 @@ impl SamplerStorage {
         }
     }
 
-    pub(crate) fn create(
+    pub(crate) unsafe fn create(
         &mut self,
         device: &DeviceContext,
         create_infos: &[SamplerCreateInfo],

--- a/nitrogen/src/resources/semaphore_pool.rs
+++ b/nitrogen/src/resources/semaphore_pool.rs
@@ -14,15 +14,15 @@ pub(crate) type Semaphore<'a> = PoolElem<'a, SemaphorePoolImpl, types::Semaphore
 pub(crate) struct SemaphorePool(pub(crate) Pool<types::Semaphore, SemaphorePoolImpl>);
 
 impl SemaphorePool {
-    pub(crate) fn new(device: Arc<DeviceContext>) -> Self {
+    pub(crate) unsafe fn new(device: Arc<DeviceContext>) -> Self {
         Self::with_capacity(device, 0)
     }
 
-    pub(crate) fn with_capacity(device: Arc<DeviceContext>, cap: usize) -> Self {
+    pub(crate) unsafe fn with_capacity(device: Arc<DeviceContext>, cap: usize) -> Self {
         SemaphorePool(Pool::with_intial_elems(SemaphorePoolImpl { device }, cap))
     }
 
-    pub(crate) fn alloc(&self) -> Semaphore<'_> {
+    pub(crate) unsafe fn alloc(&self) -> Semaphore<'_> {
         self.0.alloc()
     }
 
@@ -46,11 +46,11 @@ impl SemaphorePool {
         }))
     }
 
-    pub(crate) fn clear(&mut self) {
+    pub(crate) unsafe fn clear(&mut self) {
         self.0.clear()
     }
 
-    pub(crate) fn reset(&mut self) {
+    pub(crate) unsafe fn reset(&mut self) {
         self.0.reset()
     }
 }
@@ -67,7 +67,9 @@ impl PoolImpl<types::Semaphore> for SemaphorePoolImpl {
 
     fn free_elem(&mut self, elem: types::Semaphore) {
         use gfx::Device;
-        self.device.device.destroy_semaphore(elem);
+        unsafe {
+            self.device.device.destroy_semaphore(elem);
+        }
     }
 }
 

--- a/nitrogen/src/types.rs
+++ b/nitrogen/src/types.rs
@@ -17,7 +17,6 @@ pub(crate) type Image = <back::Backend as gfx::Backend>::Image;
 pub(crate) type ImageView = <back::Backend as gfx::Backend>::ImageView;
 pub(crate) type ShaderModule = <back::Backend as gfx::Backend>::ShaderModule;
 pub(crate) type Semaphore = <back::Backend as gfx::Backend>::Semaphore;
-pub(crate) type CommandPool<T> = gfx::CommandPool<back::Backend, T>;
 pub(crate) type QueueGroup<T> = gfx::QueueGroup<back::Backend, T>;
 pub(crate) type CommandQueue<T> = gfx::CommandQueue<back::Backend, T>;
 pub(crate) type Memory = <back::Backend as gfx::Backend>::Memory;

--- a/nitrogen/src/types.rs
+++ b/nitrogen/src/types.rs
@@ -20,3 +20,5 @@ pub(crate) type Semaphore = <back::Backend as gfx::Backend>::Semaphore;
 pub(crate) type CommandPool<T> = gfx::CommandPool<back::Backend, T>;
 pub(crate) type QueueGroup<T> = gfx::QueueGroup<back::Backend, T>;
 pub(crate) type CommandQueue<T> = gfx::CommandQueue<back::Backend, T>;
+pub(crate) type Memory = <back::Backend as gfx::Backend>::Memory;
+pub(crate) type Buffer = <back::Backend as gfx::Backend>::Buffer;

--- a/nitrogen/src/util/allocator.rs
+++ b/nitrogen/src/util/allocator.rs
@@ -1,0 +1,399 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use failure::Fail;
+
+/// The returned object representing a memory allocation
+pub(crate) trait Block: Sized {
+    fn range(&self) -> std::ops::Range<u64>;
+    fn memory(&self) -> &crate::types::Memory;
+}
+
+pub(crate) struct BufferType<A: Allocator> {
+    buffer: crate::types::Buffer,
+    block: A::Block,
+}
+
+impl<A: Allocator> BufferType<A> {
+    pub(crate) fn raw(&self) -> &crate::types::Buffer {
+        &self.buffer
+    }
+
+    pub(crate) fn block(&self) -> &A::Block {
+        &self.block
+    }
+}
+
+pub(crate) struct ImageType<A: Allocator> {
+    image: crate::types::Image,
+    block: A::Block,
+}
+
+impl<A: Allocator> ImageType<A> {
+    pub(crate) fn raw(&self) -> &crate::types::Image {
+        &self.image
+    }
+
+    pub(crate) fn block(&self) -> &A::Block {
+        &self.block
+    }
+}
+
+
+/// Errors that can occur when allocating memory from a device
+#[derive(Debug, Fail, Clone)]
+pub enum AllocationError {
+    /// No suitable memory type could be found
+    #[fail(display = "No suitable memory type could be found")]
+    NoSuitableMemoryType,
+
+    /// Not enough free memory available to perform the allocation
+    #[fail(display = "Out of memory")]
+    OutOfMemory,
+
+    /// An implementation might impose a limited number of objects
+    #[fail(display = "Too many objects")]
+    TooManyObjects,
+}
+
+#[derive(Debug, Fail, Clone)]
+pub enum AllocatorError {
+    #[fail(display = "Could not allocate memory")]
+    AllocationError(#[cause] AllocationError),
+    #[fail(display = "Could not bind resource")]
+    BindError(#[cause] gfx::device::BindError),
+    #[fail(display = "Could not create buffer")]
+    BufferCreationError(#[cause] gfx::buffer::CreationError),
+    #[fail(display = "Could not create image")]
+    ImageCreationError(#[cause] gfx::image::CreationError),
+}
+
+/// An allocation request
+pub(crate) struct Request {
+    pub(crate) transient: bool,
+    pub(crate) persistently_mappable: bool,
+    pub(crate) properties: gfx::memory::Properties,
+    pub(crate) size: u64,
+    pub(crate) alignment: u64,
+    pub(crate) type_mask: u64,
+}
+
+pub(crate) struct BufferRequest {
+    pub(crate) transient: bool,
+    pub(crate) persistently_mappable: bool,
+    pub(crate) properties: gfx::memory::Properties,
+    pub(crate) usage: gfx::buffer::Usage,
+    pub(crate) size: u64,
+}
+
+pub(crate) struct ImageRequest {
+    pub(crate) transient: bool,
+    pub(crate) properties: gfx::memory::Properties,
+    pub(crate) kind: gfx::image::Kind,
+    pub(crate) level: gfx::image::Level,
+    pub(crate) format: gfx::format::Format,
+    pub(crate) tiling: gfx::image::Tiling,
+    pub(crate) usage: gfx::image::Usage,
+    pub(crate) view_caps: gfx::image::ViewCapabilities,
+}
+
+/// The interface any memory allocator has to implement
+pub(crate) trait Allocator: std::fmt::Debug + Sized {
+
+    type Block: Block;
+
+    /// Allocate a block of memory from `device` that satisfies `reqs` and `request`
+    unsafe fn alloc(
+        &mut self,
+        device: &back::Device,
+        request: Request,
+    ) -> Result<Self::Block, AllocationError>;
+
+    /// Free a block of memory so it can be used in a later allocation
+    unsafe fn free(
+        &mut self,
+        device: &back::Device,
+        block: Self::Block,
+    );
+
+    unsafe fn create_buffer(
+        &mut self,
+        device: &back::Device,
+        request: BufferRequest,
+    ) -> Result<BufferType<Self>, AllocatorError> {
+        use gfx::Device;
+
+        let mut buf = device.create_buffer(request.size, request.usage)
+            .map_err(AllocatorError::BufferCreationError)?;
+        let reqs = device.get_buffer_requirements(&buf);
+
+        let request = Request {
+            size: reqs.size,
+            alignment: reqs.alignment,
+            type_mask: reqs.type_mask,
+            properties: request.properties,
+            transient: request.transient,
+            persistently_mappable: request.persistently_mappable,
+        };
+
+        let block = self
+            .alloc(device, request)
+            .map_err(AllocatorError::AllocationError)?;
+
+        device
+            .bind_buffer_memory(block.memory(), block.range().start, &mut buf)
+            .map_err(AllocatorError::BindError)?;
+
+        Ok(BufferType {
+            buffer: buf,
+            block,
+        })
+    }
+
+    unsafe fn create_image(
+        &mut self,
+        device: &back::Device,
+        request: ImageRequest,
+    ) -> Result<ImageType<Self>, AllocatorError> {
+        use gfx::Device;
+        let mut img = device.create_image(
+            request.kind,
+            request.level,
+            request.format,
+            request.tiling,
+            request.usage,
+            request.view_caps,
+        ).map_err(AllocatorError::ImageCreationError)?;
+
+        let reqs = device.get_image_requirements(&img);
+
+        let request = Request {
+            size: reqs.size,
+            alignment: reqs.alignment,
+            type_mask: reqs.type_mask,
+            properties: request.properties,
+            transient: request.transient,
+            persistently_mappable: false,
+        };
+
+        let block = self
+            .alloc(device, request)
+            .map_err(AllocatorError::AllocationError)?;
+
+        device
+            .bind_image_memory(block.memory(), block.range().start, &mut img)
+            .map_err(AllocatorError::BindError)?;
+
+        Ok(ImageType {
+            image: img,
+            block,
+        })
+    }
+
+    unsafe fn destroy_buffer(
+        &mut self,
+        device: &back::Device,
+        buffer: BufferType<Self>,
+    ) {
+        use gfx::Device;
+        device.destroy_buffer(buffer.buffer);
+        self.free(device, buffer.block);
+    }
+
+    unsafe fn destroy_image(
+        &mut self,
+        device: &back::Device,
+        image: ImageType<Self>,
+    ) {
+        use gfx::Device;
+        device.destroy_image(image.image);
+        self.free(device, image.block);
+    }
+
+    unsafe fn dispose(self, device: &back::Device) -> Result<(), Self>
+        where
+            Self: Sized;
+}
+
+
+#[cfg(feature = "alloc_gfxm")]
+pub(crate) use self::alloc_gfxm::reexport::*;
+
+#[cfg(not(feature = "alloc_gfxm"))]
+pub(crate) use self::alloc_empty::reexport::*;
+
+
+#[cfg(feature = "alloc_gfxm")]
+mod alloc_gfxm {
+
+    use super::*;
+
+    use gfx_memory::{
+        MemoryAllocator,
+        SmartAllocator,
+        SmartBlock,
+        Factory,
+        Block as GfxmBlock,
+    };
+
+    pub(crate) mod reexport {
+        use super::*;
+
+        pub(crate) type DefaultAlloc = AllocatorGfxm;
+        pub(crate) type Buffer = BufferType<AllocatorGfxm>;
+        pub(crate) type Image = ImageType<AllocatorGfxm>;
+    }
+
+    #[derive(Debug)]
+    pub struct BlockGfxm {
+        block: SmartBlock<crate::types::Memory>,
+    }
+
+    impl Block for BlockGfxm {
+        fn range(&self) -> std::ops::Range<u64> {
+            self.block.range()
+        }
+
+        fn memory(&self) -> &crate::types::Memory {
+            self.block.memory()
+        }
+    }
+
+    #[derive(Debug)]
+    pub(crate) struct AllocatorGfxm {
+        alloc: SmartAllocator<back::Backend>,
+    }
+
+    fn gfxm_err_to_alloc_err(err: gfx_memory::MemoryError) -> AllocationError {
+
+        println!("Encountered an error! {:?}", err);
+
+        use gfx_memory::MemoryError;
+        match err {
+            MemoryError::NoCompatibleMemoryType => AllocationError::NoSuitableMemoryType,
+            MemoryError::OutOfMemory => AllocationError::OutOfMemory,
+            MemoryError::TooManyObjects => AllocationError::TooManyObjects,
+        }
+    }
+
+    impl AllocatorGfxm {
+        pub(crate) unsafe fn new(
+            device: &back::Device,
+            props: gfx::adapter::MemoryProperties,
+        ) -> Self {
+            let alloc = SmartAllocator::new(props, 256, 64, 1024, 256 * 1024 * 1024);
+            Self {
+                alloc,
+            }
+        }
+    }
+
+    impl Allocator for AllocatorGfxm {
+        type Block = BlockGfxm;
+
+        unsafe fn alloc(
+            &mut self,
+            device: &back::Device,
+            request: Request,
+        ) -> Result<BlockGfxm, AllocationError> {
+
+            println!("alloc");
+            println!("used {}", self.alloc.used());
+            println!("requested {}", request.size);
+
+            let ty = if request.transient {
+                gfx_memory::Type::ShortLived
+            } else {
+                gfx_memory::Type::General
+            };
+
+            let prop = request.properties;
+
+            let reqs = gfx::memory::Requirements {
+                size: request.size,
+                alignment: request.alignment,
+                type_mask: request.type_mask,
+            };
+
+            let block = self.alloc.alloc(
+                device,
+                (ty, prop),
+                reqs,
+            ).map_err(gfxm_err_to_alloc_err)?;
+
+            Ok(BlockGfxm {
+                block,
+            })
+        }
+
+        unsafe fn free(
+            &mut self,
+            device: &back::Device,
+            block: BlockGfxm,
+        ) {
+            self.alloc.free(
+                device,
+                block.block,
+            )
+        }
+
+        unsafe fn dispose(self, device: &back::Device) -> Result<(), Self> {
+            self.alloc.dispose(device).map_err(|alloc| Self { alloc })
+        }
+    }
+
+}
+
+
+#[cfg(not(feature = "alloc_gfxm"))]
+mod alloc_empty {
+    use super::*;
+
+    pub(crate) mod reexport {
+        use super::*;
+
+        pub(crate) type DefaultAlloc = AllocatorEmpty;
+        pub(crate) type Buffer = BufferType<AllocatorEmpty>;
+        pub(crate) type Image = ImageType<AllocatorEmpty>;
+    }
+
+    struct BlockEmpty;
+
+    impl Block for BlockEmpty {
+        fn range(&self) -> std::ops::Range<u64> {
+            unimplemented!()
+        }
+
+        fn memory(&self) -> &crate::types::Memory {
+            unimplemented!()
+        }
+    }
+
+    #[derive(Debug)]
+    pub(crate) struct AllocatorEmpty;
+
+    impl Allocator for AllocatorEmpty {
+        type Block = BlockEmpty;
+
+        unsafe fn alloc(
+            &mut self,
+            _: &back::Device,
+            _: Request,
+        ) -> Result<BlockEmpty, AllocationError> {
+            unimplemented!("empty memory allocator used")
+        }
+
+        unsafe fn free(
+            &mut self,
+            _: &back::Device,
+            _: BlockEmpty,
+        ) {
+            unimplemented!("empty memory allocator used")
+        }
+
+        unsafe fn dispose(self, _: &back::Device) -> Result<(), Self> {
+            Ok(())
+        }
+    }
+}

--- a/nitrogen/src/util/mod.rs
+++ b/nitrogen/src/util/mod.rs
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+pub(crate) mod allocator;
 pub(crate) mod pool;
 pub mod storage;
 pub mod submit_group;
 pub(crate) mod transfer;
-pub(crate) mod allocator;
 
 use std::borrow::Cow;
 

--- a/nitrogen/src/util/mod.rs
+++ b/nitrogen/src/util/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod pool;
 pub mod storage;
 pub mod submit_group;
 pub(crate) mod transfer;
+pub(crate) mod allocator;
 
 use std::borrow::Cow;
 

--- a/nitrogen/src/util/pool.rs
+++ b/nitrogen/src/util/pool.rs
@@ -21,12 +21,19 @@ pub(crate) trait PoolImpl<T> {
 pub(crate) struct PoolInner<T, Impl: PoolImpl<T>> {
     pool_impl: Impl,
     pub(crate) values: Vec<T>,
+    // elements which are currently in use will be None
+    // elements which are not used will point to the next free element
+    //
+    // that means to query for alive status the next field can be used.
     nexts: Vec<Option<usize>>,
-    next_free: Option<usize>,
+    next_free: usize,
     size: usize,
 }
 
-/// A pool to insert (or allocate) items which can be reused after freeing
+/// A pool to insert (or allocate) items which can be reused after freeing.
+///
+/// This pool allocates a number of resources which are kept alive rather than destroying
+/// and recreating resources. (like a slab would do)
 pub(crate) struct Pool<T, Impl: PoolImpl<T>> {
     inner: UnsafeCell<PoolInner<T, Impl>>,
 }
@@ -44,14 +51,12 @@ impl<T, Impl: PoolImpl<T>> Pool<T, Impl> {
         }
 
         let mut nexts = Vec::with_capacity(cap);
-        if cap > 0 {
-            for i in 0..(cap - 1) {
-                nexts.push(Some(i + 1));
-            }
-            nexts.push(None);
+
+        for i in 0..cap {
+            nexts.push(Some((i + 1) % cap));
         }
 
-        let next_free = if cap > 0 { Some(0) } else { None };
+        let next_free = 0;
 
         Pool {
             inner: UnsafeCell::new(PoolInner {
@@ -65,9 +70,7 @@ impl<T, Impl: PoolImpl<T>> Pool<T, Impl> {
     }
 
     pub(crate) unsafe fn get(&self) -> &mut PoolInner<T, Impl> {
-        use std::mem::transmute;
-
-        transmute(self.inner.get())
+        &mut *self.inner.get()
     }
 
     #[allow(unused)]
@@ -78,14 +81,17 @@ impl<T, Impl: PoolImpl<T>> Pool<T, Impl> {
     pub(crate) fn alloc(&self) -> PoolElem<'_, Impl, T> {
         let this = unsafe { self.get() };
 
-        let next = this.next_free.unwrap_or_else(|| {
+        let next = if this.size == this.values.len() {
             let next = this.values.len();
             this.values.push(this.pool_impl.new_elem());
-            this.nexts.push(None);
+            this.nexts.push(Some(this.next_free));
             next
-        });
+        } else {
+            this.next_free
+        };
 
-        this.next_free = this.nexts[next];
+        this.next_free = this.nexts[next].unwrap();
+        this.nexts[next] = None;
 
         this.size += 1;
 
@@ -93,8 +99,6 @@ impl<T, Impl: PoolImpl<T>> Pool<T, Impl> {
     }
 
     unsafe fn free_on_drop(&self, idx: usize) {
-        let this = self.get();
-
         if Impl::free_on_drop() {
             self.free(idx);
         }
@@ -105,8 +109,8 @@ impl<T, Impl: PoolImpl<T>> Pool<T, Impl> {
 
         this.pool_impl.reset_elem(&mut this.values[idx]);
 
-        this.nexts[idx] = this.next_free;
-        this.next_free = Some(idx);
+        this.nexts[idx] = Some(this.next_free);
+        this.next_free = idx;
 
         this.size -= 1;
     }
@@ -116,25 +120,21 @@ impl<T, Impl: PoolImpl<T>> Pool<T, Impl> {
 
         this.size = 0;
 
+        for (i, val) in this.values.iter_mut().enumerate() {
+            if this.nexts[i].is_none() {
+                this.pool_impl.reset_elem(val);
+            }
+        }
+
         for i in 0..this.nexts.len() {
             this.nexts[i] = Some((i + 1) % this.nexts.len());
         }
 
-        for (i, val) in this.values.iter_mut().enumerate() {
-            this.pool_impl.reset_elem(val);
-        }
-
-        if this.values.len() > 0 {
-            this.next_free = Some(0);
-        } else {
-            this.next_free = None;
-        }
+        this.next_free = 0;
     }
 
     pub(crate) fn reset(&mut self) {
         let this = unsafe { self.get() };
-
-        use std::mem::replace;
 
         for val in this.values.drain(0..) {
             this.pool_impl.free_elem(val);

--- a/nitrogen/src/util/submit_group.rs
+++ b/nitrogen/src/util/submit_group.rs
@@ -10,6 +10,9 @@ use crate::image::ImageType;
 use crate::device::DeviceContext;
 use crate::*;
 
+use crate::resources::command_pool::{
+    CommandPoolCompute, CommandPoolGraphics, CommandPoolTransfer,
+};
 use crate::resources::semaphore_pool::{SemaphoreList, SemaphorePool};
 
 use smallvec::SmallVec;
@@ -34,43 +37,47 @@ use std::sync::Arc;
 pub struct SubmitGroup {
     sem_pool: SemaphorePool,
 
-    pool_graphics: types::CommandPool<gfx::Graphics>,
-    pool_compute: types::CommandPool<gfx::Compute>,
-    pool_transfer: types::CommandPool<gfx::Transfer>,
+    pool_graphics: CommandPoolGraphics,
+    pool_compute: CommandPoolCompute,
+    pool_transfer: CommandPoolTransfer,
 
     sem_list: SemaphoreList,
     res_destroys: ResourceList,
 }
 
 impl SubmitGroup {
-    pub(crate) fn new(device: Arc<DeviceContext>) -> Self {
+    pub(crate) unsafe fn new(device: Arc<DeviceContext>) -> Self {
         let (gfx, cmpt, trns) = {
             let gfx = device
                 .device
                 .create_command_pool_typed(
                     device.graphics_queue_group(),
+                    // gfx::pool::CommandPoolCreateFlags::RESET_INDIVIDUAL,
                     gfx::pool::CommandPoolCreateFlags::empty(),
-                    0,
                 )
                 .unwrap();
             let cmpt = device
                 .device
                 .create_command_pool_typed(
                     device.compute_queue_group(),
+                    // gfx::pool::CommandPoolCreateFlags::RESET_INDIVIDUAL,
                     gfx::pool::CommandPoolCreateFlags::empty(),
-                    0,
                 )
                 .unwrap();
             let trns = device
                 .device
                 .create_command_pool_typed(
                     device.transfer_queue_group(),
+                    // gfx::pool::CommandPoolCreateFlags::RESET_INDIVIDUAL,
                     gfx::pool::CommandPoolCreateFlags::empty(),
-                    0,
                 )
                 .unwrap();
 
-            (gfx, cmpt, trns)
+            (
+                CommandPoolGraphics::new(gfx),
+                CommandPoolCompute::new(cmpt),
+                CommandPoolTransfer::new(trns),
+            )
         };
 
         SubmitGroup {
@@ -85,13 +92,51 @@ impl SubmitGroup {
         }
     }
 
+    pub unsafe fn wait(&mut self, ctx: &mut Context) {
+        let mut fence = ctx.device_ctx.device.create_fence(false).unwrap();
+
+        {
+            let submit = gfx::Submission {
+                command_buffers: None,
+                wait_semaphores: self
+                    .sem_pool
+                    .list_prev_sems(&self.sem_list)
+                    .map(|sem| (sem, gfx::pso::PipelineStage::BOTTOM_OF_PIPE)),
+                signal_semaphores: self.sem_pool.list_next_sems(&self.sem_list),
+            };
+
+            ctx.device_ctx
+                .transfer_queue()
+                .submit::<gfx::command::CommandBuffer<
+                    back::Backend,
+                    gfx::Transfer,
+                    gfx::command::OneShot,
+                    gfx::command::Primary,
+                >, _, _, _, _>(submit, Some(&mut fence));
+
+            ctx.device_ctx.device.wait_for_fence(&fence, !0).unwrap();
+        }
+
+        self.sem_list.advance();
+
+        self.res_destroys.free_resources();
+
+        self.pool_graphics.reset();
+        self.pool_compute.reset();
+        self.pool_transfer.reset();
+
+        ctx.device_ctx.device.destroy_fence(fence);
+
+        self.sem_pool.clear();
+    }
+
     /// Present an image to a display.
     ///
     /// If the image to be presented is a result of a graph execution, use
     /// [`Context::graph_get_output_image`] to retrieve the `ImageHandle`.
     ///
     /// [`Context::graph_get_output_image`]: ../../struct.Context.html#method.graph_get_output_image
-    pub fn display_present(
+    pub unsafe fn display_present(
         &mut self,
         ctx: &mut Context,
         display: DisplayHandle,
@@ -101,17 +146,17 @@ impl SubmitGroup {
             &ctx.device_ctx,
             &mut self.sem_pool,
             &mut self.sem_list,
-            &mut self.pool_graphics,
+            &self.pool_graphics,
             &ctx.image_storage,
             image,
         )
     }
 
-    pub fn display_setup_swapchain(&mut self, ctx: &mut Context, display: DisplayHandle) {
+    pub unsafe fn display_setup_swapchain(&mut self, ctx: &mut Context, display: DisplayHandle) {
         ctx.displays[display].setup_swapchain(&ctx.device_ctx, &mut self.res_destroys);
     }
 
-    pub fn graph_execute(
+    pub unsafe fn graph_execute(
         &mut self,
         ctx: &mut Context,
         graph: graph::GraphHandle,
@@ -132,8 +177,8 @@ impl SubmitGroup {
             &ctx.device_ctx,
             &mut self.sem_pool,
             &mut self.sem_list,
-            &mut self.pool_graphics,
-            &mut self.pool_compute,
+            &self.pool_graphics,
+            &self.pool_compute,
             &mut self.res_destroys,
             &mut storages,
             store,
@@ -167,7 +212,7 @@ impl SubmitGroup {
         }
     }
 
-    pub fn image_upload_data(
+    pub unsafe fn image_upload_data(
         &mut self,
         ctx: &mut Context,
         images: &[(image::ImageHandle, image::ImageUploadInfo)],
@@ -176,7 +221,7 @@ impl SubmitGroup {
             &ctx.device_ctx,
             &self.sem_pool,
             &mut self.sem_list,
-            &mut self.pool_transfer,
+            &self.pool_transfer,
             &mut self.res_destroys,
             images,
         )
@@ -186,7 +231,7 @@ impl SubmitGroup {
         ctx.image_storage.destroy(&mut self.res_destroys, images)
     }
 
-    pub fn buffer_cpu_visible_upload<T>(
+    pub unsafe fn buffer_cpu_visible_upload<T>(
         &mut self,
         ctx: &mut Context,
         data: &[(buffer::BufferHandle, buffer::BufferUploadInfo<T>)],
@@ -194,7 +239,7 @@ impl SubmitGroup {
         ctx.buffer_storage.cpu_visible_upload(&ctx.device_ctx, data)
     }
 
-    pub fn buffer_cpu_visible_read<T>(
+    pub unsafe fn buffer_cpu_visible_read<T>(
         &mut self,
         ctx: &Context,
         buffer: buffer::BufferHandle,
@@ -204,7 +249,7 @@ impl SubmitGroup {
             .cpu_visible_read(&ctx.device_ctx, buffer, data);
     }
 
-    pub fn buffer_device_local_upload<T>(
+    pub unsafe fn buffer_device_local_upload<T>(
         &mut self,
         ctx: &mut Context,
         data: &[(buffer::BufferHandle, buffer::BufferUploadInfo<T>)],
@@ -213,7 +258,7 @@ impl SubmitGroup {
             &ctx.device_ctx,
             &self.sem_pool,
             &mut self.sem_list,
-            &mut self.pool_transfer,
+            &self.pool_transfer,
             &mut self.res_destroys,
             data,
         )
@@ -228,46 +273,25 @@ impl SubmitGroup {
             .destroy(&mut self.res_destroys, samplers)
     }
 
-    pub fn wait(&mut self, ctx: &mut Context) {
-        let mut fence = ctx.device_ctx.device.create_fence(false).unwrap();
-
+    pub unsafe fn release(mut self, ctx: &mut Context) {
         {
-            let submit = gfx::Submission::new().wait_on(
-                self.sem_pool
-                    .list_prev_sems(&self.sem_list)
-                    .map(|sem| (sem, gfx::pso::PipelineStage::BOTTOM_OF_PIPE)),
-            );
-
+            let pool = self.pool_graphics.0.into_impl();
             ctx.device_ctx
-                .transfer_queue()
-                .submit(submit, Some(&mut fence));
-
-            ctx.device_ctx.device.wait_for_fence(&fence, !0).unwrap();
+                .device
+                .destroy_command_pool(pool.pool.into_raw());
         }
-
-        self.sem_list.advance();
-
-        ctx.device_ctx.device.destroy_fence(fence);
-
-        self.res_destroys.free_resources();
-
-        self.sem_pool.clear();
-
-        self.pool_graphics.reset();
-        self.pool_compute.reset();
-        self.pool_transfer.reset();
-    }
-
-    pub fn release(mut self, ctx: &mut Context) {
-        ctx.device_ctx
-            .device
-            .destroy_command_pool(self.pool_graphics.into_raw());
-        ctx.device_ctx
-            .device
-            .destroy_command_pool(self.pool_compute.into_raw());
-        ctx.device_ctx
-            .device
-            .destroy_command_pool(self.pool_transfer.into_raw());
+        {
+            let pool = self.pool_compute.0.into_impl();
+            ctx.device_ctx
+                .device
+                .destroy_command_pool(pool.pool.into_raw());
+        }
+        {
+            let pool = self.pool_transfer.0.into_impl();
+            ctx.device_ctx
+                .device
+                .destroy_command_pool(pool.pool.into_raw());
+        }
 
         self.sem_pool.reset();
     }
@@ -351,7 +375,7 @@ impl ResourceList {
         self.desc_pools.push(pool);
     }
 
-    fn free_resources(&mut self) {
+    unsafe fn free_resources(&mut self) {
         use gfxm::Factory;
 
         let mut alloc = self.device.allocator();

--- a/nitrogen/src/util/submit_group.rs
+++ b/nitrogen/src/util/submit_group.rs
@@ -376,7 +376,7 @@ impl ResourceList {
     }
 
     unsafe fn free_resources(&mut self) {
-        use gfxm::Factory;
+        use crate::util::allocator::Allocator;
 
         let mut alloc = self.device.allocator();
 

--- a/nitrogen/src/util/transfer.rs
+++ b/nitrogen/src/util/transfer.rs
@@ -12,7 +12,6 @@ use crate::device::DeviceContext;
 use crate::resources::command_pool::CommandPoolTransfer;
 use crate::resources::semaphore_pool::SemaphoreList;
 use crate::resources::semaphore_pool::SemaphorePool;
-use crate::types::CommandPool;
 
 pub(crate) struct BufferTransfer<'a> {
     pub(crate) src: &'a BufferTypeInternal,


### PR DESCRIPTION
This PR updates `gfx-hal` and `winit` to their latest gfx-hal supported versions.

While doing this, following things have been added:

 - abstraction for memory allocators, currently only `gfx-memory` is used
 - `CommandBuffer`s now use the same pooling mechanism as `Semaphore`s

Also changed was the way the final blitting for presenting to the screen was done. The memory barriers were set up wrong, causing black-screens on AMD OSS drivers (but not on AMD prop or Nvidia prop)