### PR TITLE
various updates to examples, per-SubmitGroup graph resources

### DIFF
--- a/examples/2d-squares/main.rs
+++ b/examples/2d-squares/main.rs
@@ -232,7 +232,7 @@ fn create_graph(
                 ),)),
                 entry: "ComputeMain".into(),
             },
-            materials: vec![(1, material)],
+            materials: vec![(0, material)],
             push_constants: vec![(0..4)],
         };
 
@@ -267,7 +267,7 @@ fn create_graph(
 
                     cmd.push_constant::<f32>(2, *delta as f32);
 
-                    cmd.bind_material(1, self.mat_instance);
+                    cmd.bind_material(0, self.mat_instance);
 
                     cmd.dispatch([wide, batch_size, 1]);
                 }
@@ -303,7 +303,7 @@ fn create_graph(
             },
             primitive: graph::Primitive::TriangleStrip,
             blend_modes: vec![graph::BlendMode::Alpha],
-            materials: vec![(1, material)],
+            materials: vec![(0, material)],
             push_constants: vec![(0..5)],
         };
 
@@ -343,7 +343,7 @@ fn create_graph(
                     cmd.push_constant(4, *s);
 
                     cmd.bind_vertex_buffers(&[(self.buffer, 0)]);
-                    cmd.bind_material(1, self.mat_instance);
+                    cmd.bind_material(0, self.mat_instance);
 
                     cmd.draw(0..4, 0..things as u32);
                 }

--- a/examples/2d-squares/main.rs
+++ b/examples/2d-squares/main.rs
@@ -33,7 +33,7 @@ const VERTEX_DATA: [VertexData; 4] = [
     VertexData { pos: [1.0, 1.0] },
 ];
 
-const NUM_THINGS: usize = 1_024 * 1_024 * 4;
+const NUM_THINGS: usize = 1_024;
 
 struct Data2dSquares {
     graph: graph::GraphHandle,
@@ -68,10 +68,10 @@ impl UserData for Data2dSquares {
             &[self.buf_vertex, self.buf_instance, self.buf_velocity],
         );
 
+        submit.material_destroy(&[self.mat]);
+
         unsafe {
             submit.wait(ctx);
-
-            ctx.material_destroy(&[self.mat]);
         }
 
         ctx.vertex_attribs_destroy(&[self.vtx_def]);

--- a/examples/2d-squares/shaders/move.hlsl
+++ b/examples/2d-squares/shaders/move.hlsl
@@ -21,10 +21,10 @@ struct Instance {
     float4 color;
 };
 
-[[vk::binding(0, 1)]]
+[[vk::binding(0, 0)]]
 RWStructuredBuffer<Instance> instances;
 
-[[vk::binding(1, 1)]]
+[[vk::binding(1, 0)]]
 RWStructuredBuffer<float2> velocities;
 
 

--- a/examples/2d-squares/shaders/quad.hlsl
+++ b/examples/2d-squares/shaders/quad.hlsl
@@ -37,7 +37,7 @@ struct InstanceData {
     float4 color;
 };
 
-[[vk::binding(0, 1)]]
+[[vk::binding(0, 0)]]
 StructuredBuffer<InstanceData> data;
 
 VertexOut VertexMain(VertexIn input)

--- a/examples/common/src/main_loop.rs
+++ b/examples/common/src/main_loop.rs
@@ -12,12 +12,16 @@ use std::time::Instant;
 
 pub struct CanvasSize(pub f32, pub f32);
 
-pub trait UserData {
+pub trait UserData: Sized {
     fn iteration(&mut self, _store: &mut graph::Store, _delta: f64) {}
 
     fn graph(&self) -> graph::GraphHandle;
 
     fn output_image(&self) -> graph::ResourceName;
+
+    fn release(self, ctx: &mut Context, submit: &mut SubmitGroup) {
+        submit.graph_destroy(ctx, &[self.graph()]);
+    }
 }
 
 pub struct MainLoop<U: UserData> {
@@ -40,15 +44,15 @@ pub struct MainLoop<U: UserData> {
 }
 
 impl<U: UserData> MainLoop<U> {
-    pub unsafe fn new<F>(name: &str, f: F) -> Self
+    pub unsafe fn new<F>(name: &str, f: F) -> Option<Self>
     where
-        F: FnOnce(&mut Store, &mut Context, &mut SubmitGroup) -> U,
+        F: FnOnce(&mut Store, &mut Context, &mut SubmitGroup) -> Option<U>,
     {
         let events_loop = EventsLoop::new();
         let window = WindowBuilder::new()
             .with_title(name)
             .build(&events_loop)
-            .unwrap();
+            .ok()?;
 
         let mut ctx = Context::new(name, 1);
         let display = ctx.display_add(&window);
@@ -63,13 +67,23 @@ impl<U: UserData> MainLoop<U> {
 
         store.insert(CanvasSize(size.0, size.1));
 
-        let mut submits = vec![ctx.create_submit_group(), ctx.create_submit_group()];
+        let mut submits = vec![ctx.create_submit_group()];
 
-        let user_data = f(&mut store, &mut ctx, &mut submits[0]);
+        let user_data = match f(&mut store, &mut ctx, &mut submits[0]) {
+            Some(d) => d,
+            None => {
+                for s in submits {
+                    s.release(&mut ctx);
+                }
+
+                ctx.release();
+                return None;
+            }
+        };
 
         let instant = Instant::now();
 
-        MainLoop {
+        Some(MainLoop {
             events_loop,
             _window: window,
 
@@ -86,7 +100,7 @@ impl<U: UserData> MainLoop<U> {
 
             submits,
             submit_idx: 0,
-        }
+        })
     }
 
     pub fn running(&self) -> bool {
@@ -164,7 +178,8 @@ impl<U: UserData> MainLoop<U> {
     }
 
     pub unsafe fn release(mut self) {
-        self.submits[self.submit_idx].graph_destroy(&mut self.ctx, &[self.user_data.graph()]);
+        self.user_data
+            .release(&mut self.ctx, &mut self.submits[self.submit_idx]);
 
         self.ctx.wait_idle();
 

--- a/examples/common/src/main_loop.rs
+++ b/examples/common/src/main_loop.rs
@@ -67,7 +67,12 @@ impl<U: UserData> MainLoop<U> {
 
         store.insert(CanvasSize(size.0, size.1));
 
-        let mut submits = vec![ctx.create_submit_group()];
+        let mut submits = vec![
+            ctx.create_submit_group(),
+            ctx.create_submit_group(),
+            ctx.create_submit_group(),
+            ctx.create_submit_group(),
+        ];
 
         let user_data = match f(&mut store, &mut ctx, &mut submits[0]) {
             Some(d) => d,
@@ -169,7 +174,7 @@ impl<U: UserData> MainLoop<U> {
 
             submit.graph_execute(&mut self.ctx, graph, &mut self.store, &context);
 
-            let image = self.ctx.graph_get_output_image(graph, image).unwrap();
+            let image = submit.graph_get_image(&self.ctx, graph, image).unwrap();
 
             submit.display_present(&mut self.ctx, self.display, image);
         }

--- a/examples/common/src/main_loop.rs
+++ b/examples/common/src/main_loop.rs
@@ -183,6 +183,12 @@ impl<U: UserData> MainLoop<U> {
     }
 
     pub unsafe fn release(mut self) {
+        for submit_group in &mut self.submits {
+            submit_group.wait(&mut self.ctx);
+        }
+
+        self.ctx.wait_idle();
+
         self.user_data
             .release(&mut self.ctx, &mut self.submits[self.submit_idx]);
 

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -142,7 +142,7 @@ fn create_graph(
                     "/compute/add.hlsl.comp.spirv"
                 ),)),
             },
-            materials: vec![(1, material_instance.0)],
+            materials: vec![(0, material_instance.0)],
             push_constants: vec![0..1],
         };
 
@@ -159,7 +159,7 @@ fn create_graph(
 
             fn execute(&self, _: &Store, command_buffer: &mut ComputeCommandBuffer<'_>) {
                 unsafe {
-                    command_buffer.bind_material(1, self.mat);
+                    command_buffer.bind_material(0, self.mat);
                     command_buffer.push_constant(0, 1_f32);
 
                     command_buffer.dispatch([NUM_ELEMS as _, 1, 1]);
@@ -183,7 +183,7 @@ fn create_graph(
                     "/compute/add.hlsl.comp.spirv"
                 ),)),
             },
-            materials: vec![(1, material_instance.0)],
+            materials: vec![(0, material_instance.0)],
             push_constants: vec![0..1],
         };
 
@@ -200,7 +200,7 @@ fn create_graph(
 
             fn execute(&self, _: &Store, command_buffer: &mut ComputeCommandBuffer<'_>) {
                 unsafe {
-                    command_buffer.bind_material(1, self.mat);
+                    command_buffer.bind_material(0, self.mat);
                     command_buffer.push_constant(0, 10.0_f32);
 
                     command_buffer.dispatch([NUM_ELEMS as _, 1, 1]);

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -114,6 +114,7 @@ fn main() {
 
     submit.buffer_destroy(&mut ctx, &[buffer]);
     submit.graph_destroy(&mut ctx, &[graph]);
+    submit.material_destroy(&[material]);
 
     unsafe {
         ctx.wait_idle();
@@ -122,7 +123,6 @@ fn main() {
 
         submit.release(&mut ctx);
 
-        ctx.material_destroy(&[material]);
         ctx.release();
     }
 }

--- a/examples/compute/shaders/add.hlsl
+++ b/examples/compute/shaders/add.hlsl
@@ -10,7 +10,7 @@ struct PushData {
 ConstantBuffer<PushData> push_data;
 
 
-[[vk::binding(0, 1)]]
+[[vk::binding(0, 0)]]
 RWStructuredBuffer<float> data;
 
 struct DispatchInput {

--- a/examples/model/main.rs
+++ b/examples/model/main.rs
@@ -30,6 +30,7 @@ fn main() {
 struct Data {
     buf_position: buffer::BufferHandle,
     buf_normal: buffer::BufferHandle,
+    buf_index: buffer::BufferHandle,
 
     vtx_def: vertex_attrib::VertexAttribHandle,
 
@@ -54,7 +55,7 @@ impl main_loop::UserData for Data {
     fn release(self, ctx: &mut Context, submit: &mut submit_group::SubmitGroup) {
         submit.graph_destroy(ctx, &[self.graph]);
 
-        submit.buffer_destroy(ctx, &[self.buf_normal, self.buf_position]);
+        submit.buffer_destroy(ctx, &[self.buf_normal, self.buf_position, self.buf_index]);
 
         unsafe {
             submit.wait(ctx);
@@ -124,6 +125,7 @@ fn init_resources(
     Some(Data {
         buf_position: b_position,
         buf_normal: b_normal,
+        buf_index: b_index,
 
         vtx_def: vertex_def,
 

--- a/examples/model/main.rs
+++ b/examples/model/main.rs
@@ -15,7 +15,8 @@ fn main() {
     std::env::set_var("RUST_LOG", "debug");
     env_logger::init();
 
-    let mut ml = unsafe { main_loop::MainLoop::new("Nitrogen - Model example", init_resources) };
+    let mut ml =
+        unsafe { main_loop::MainLoop::new("Nitrogen - Model example", init_resources) }.unwrap();
 
     while ml.running() {
         unsafe { ml.iterate() };
@@ -27,8 +28,11 @@ fn main() {
 }
 
 struct Data {
-    _b_position: buffer::BufferHandle,
-    _b_normal: buffer::BufferHandle,
+    buf_position: buffer::BufferHandle,
+    buf_normal: buffer::BufferHandle,
+
+    vtx_def: vertex_attrib::VertexAttribHandle,
+
     graph: graph::GraphHandle,
 }
 
@@ -46,13 +50,25 @@ impl main_loop::UserData for Data {
     fn output_image(&self) -> graph::ResourceName {
         "Base".into()
     }
+
+    fn release(self, ctx: &mut Context, submit: &mut submit_group::SubmitGroup) {
+        submit.graph_destroy(ctx, &[self.graph]);
+
+        submit.buffer_destroy(ctx, &[self.buf_normal, self.buf_position]);
+
+        unsafe {
+            submit.wait(ctx);
+        }
+
+        ctx.vertex_attribs_destroy(&[self.vtx_def]);
+    }
 }
 
 fn init_resources(
     store: &mut graph::Store,
     ctx: &mut Context,
     submit: &mut submit_group::SubmitGroup,
-) -> Data {
+) -> Option<Data> {
     store.insert(Rad(0 as f32));
 
     let mesh = {
@@ -64,11 +80,11 @@ fn init_resources(
     };
 
     let b_position =
-        unsafe { device_local_buffer_vertex(ctx, submit, &mesh.positions[..]).unwrap() };
+        unsafe { buffer_device_local_vertex(ctx, submit, &mesh.positions[..]).unwrap() };
 
-    let b_normal = unsafe { device_local_buffer_vertex(ctx, submit, &mesh.normals[..]).unwrap() };
+    let b_normal = unsafe { buffer_device_local_vertex(ctx, submit, &mesh.normals[..]).unwrap() };
 
-    let b_index = unsafe { device_local_buffer_index(ctx, submit, &mesh.indices[..]).unwrap() };
+    let b_index = unsafe { buffer_device_local_index(ctx, submit, &mesh.indices[..]).unwrap() };
 
     let vertex_def = {
         let create_info = vertex_attrib::VertexAttribInfo {
@@ -105,11 +121,14 @@ fn init_resources(
         mesh.indices.len(),
     );
 
-    Data {
-        _b_position: b_position,
-        _b_normal: b_normal,
+    Some(Data {
+        buf_position: b_position,
+        buf_normal: b_normal,
+
+        vtx_def: vertex_def,
+
         graph,
-    }
+    })
 }
 
 fn create_graph(

--- a/examples/multi-target/main.rs
+++ b/examples/multi-target/main.rs
@@ -58,11 +58,10 @@ impl UserData for Data {
         submit.buffer_destroy(ctx, &self.bufs);
         submit.image_destroy(ctx, &[self.img]);
         submit.sampler_destroy(ctx, &[self.sampler]);
+        submit.material_destroy(&[self.mat]);
 
         unsafe {
             submit.wait(ctx);
-
-            ctx.material_destroy(&[self.mat]);
         }
 
         ctx.vertex_attribs_destroy(&[self.vtx_def]);

--- a/examples/multi-target/main.rs
+++ b/examples/multi-target/main.rs
@@ -262,12 +262,12 @@ fn setup_graphs(
             move |cmd| unsafe {
                 cmd.bind_vertex_buffers(&[(buffer_pos, 0), (buffer_uv, 0)]);
 
-                cmd.bind_material(1, material_instance);
+                cmd.bind_material(0, material_instance);
 
                 cmd.draw(0..4, 0..1);
             },
             vertex_attrib.clone(),
-            vec![(1, material)],
+            vec![(0, material)],
             3,
         );
 

--- a/examples/multi-target/shaders/split.hlsl
+++ b/examples/multi-target/shaders/split.hlsl
@@ -26,9 +26,9 @@ struct FragmentOut {
     float color_blue;
 };
 
-[[vk::binding(0, 1)]]
+[[vk::binding(0, 0)]]
 Texture2D t;
-[[vk::binding(1, 1)]]
+[[vk::binding(1, 0)]]
 SamplerState s;
 
 VertexOut VertexMain(VertexIn input)

--- a/examples/multi-target/shaders/split.hlsl
+++ b/examples/multi-target/shaders/split.hlsl
@@ -31,11 +31,6 @@ Texture2D t;
 [[vk::binding(1, 1)]]
 SamplerState s;
 
-[[vk::binding(2, 1)]]
-cbuffer {
-    float4 modulate;
-};
-
 VertexOut VertexMain(VertexIn input)
 {
     VertexOut output;

--- a/examples/opaque-alpha/main.rs
+++ b/examples/opaque-alpha/main.rs
@@ -32,7 +32,6 @@ fn main() {
             .unwrap();
 
     while ml.running() {
-        println!("frame start");
         unsafe {
             ml.iterate();
         }

--- a/examples/opaque-alpha/main.rs
+++ b/examples/opaque-alpha/main.rs
@@ -28,7 +28,8 @@ fn main() {
     env_logger::init();
 
     let mut ml =
-        unsafe { main_loop::MainLoop::new("Nitrogen - Opaque-Alpha example", init_resources) };
+        unsafe { main_loop::MainLoop::new("Nitrogen - Opaque-Alpha example", init_resources) }
+            .unwrap();
 
     while ml.running() {
         println!("frame start");
@@ -60,7 +61,7 @@ fn init_resources(
     store: &mut graph::Store,
     ctx: &mut Context,
     _submit: &mut submit_group::SubmitGroup,
-) -> Resources {
+) -> Option<Resources> {
     store.insert(Quads::default());
     store.insert(QuadsAlpha::default());
 
@@ -100,7 +101,7 @@ fn init_resources(
     });
     let graph = create_graph(ctx);
 
-    Resources { graph }
+    Some(Resources { graph })
 }
 
 fn create_graph(ctx: &mut Context) -> graph::GraphHandle {

--- a/examples/two-pass/main.rs
+++ b/examples/two-pass/main.rs
@@ -399,12 +399,12 @@ fn setup_graphs(
             move |cmd| unsafe {
                 cmd.bind_vertex_buffers(&[(buffer_pos, 0), (buffer_uv, 0)]);
 
-                cmd.bind_material(1, material_instance);
+                cmd.bind_material(0, material_instance);
 
                 cmd.draw(0..4, 0..1);
             },
             vertex_attrib.clone(),
-            vec![(1, material)],
+            vec![(0, material)],
         );
 
         ntg.graph_add_graphics_pass(graph, "TestPass", info, pass_impl);

--- a/examples/two-pass/main.rs
+++ b/examples/two-pass/main.rs
@@ -318,7 +318,9 @@ fn main() {
 
             submits[frame_idx].graph_execute(&mut ntg, graph, &store, &exec_context);
 
-            let img = ntg.graph_get_output_image(graph, "IOutput").unwrap();
+            let img = submits[frame_idx]
+                .graph_get_image(&ntg, graph, "IOutput")
+                .unwrap();
 
             submits[frame_idx].display_present(&mut ntg, display, img);
         }
@@ -331,6 +333,7 @@ fn main() {
     submits[0].image_destroy(&mut ntg, &[image]);
     submits[0].sampler_destroy(&mut ntg, &[sampler]);
     submits[0].graph_destroy(&mut ntg, &[graph]);
+    submits[0].material_destroy(&[material]);
 
     for mut submit in submits {
         unsafe {
@@ -340,8 +343,6 @@ fn main() {
     }
 
     unsafe {
-        ntg.material_destroy(&[material]);
-
         ntg.release();
     }
 }

--- a/examples/two-pass/shaders/test.hlsl
+++ b/examples/two-pass/shaders/test.hlsl
@@ -22,12 +22,12 @@ struct FragmentOut {
     float4 color;
 };
 
-[[vk::binding(0, 1)]]
+[[vk::binding(0, 0)]]
 Texture2D t;
-[[vk::binding(1, 1)]]
+[[vk::binding(1, 0)]]
 SamplerState s;
 
-[[vk::binding(2, 1)]]
+[[vk::binding(2, 0)]]
 cbuffer {
     float4 modulate;
 };

--- a/nitrogen/src/display.rs
+++ b/nitrogen/src/display.rs
@@ -29,11 +29,21 @@ pub struct Display {
 impl Display {
     /// Create a new `DisplayContext` which uses the provided surface.
     pub(crate) fn new(surface: Surface, device: &DeviceContext) -> Self {
+        use gfx::format::Format;
         use gfx::Surface;
 
         let (_, formats, _, _) = surface.compatibility(&device.adapter.physical_device);
 
-        let format = formats.unwrap().remove(0);
+        println!("{:?}", formats);
+        let format = formats
+            .unwrap()
+            .into_iter()
+            .find(|format| match format {
+                Format::Rgba8Unorm => true,
+                Format::Bgra8Unorm => true,
+                _ => false,
+            })
+            .expect("No suitable display format found");
 
         Display {
             surface,

--- a/nitrogen/src/graph/command.rs
+++ b/nitrogen/src/graph/command.rs
@@ -100,7 +100,7 @@ impl<'a> GraphicsCommandBuffer<'a> {
         let layout = self.pipeline_layout;
 
         let mat = self.storages.material.raw(material.0)?;
-        let instance = mat.intance_raw(material.1)?;
+        let instance = mat.instance_raw(material.1)?;
 
         let set = &instance.set;
 
@@ -152,7 +152,7 @@ impl<'a> ComputeCommandBuffer<'a> {
         let layout = self.pipeline_layout;
 
         let mat = self.storages.material.raw(material.0)?;
-        let instance = mat.intance_raw(material.1)?;
+        let instance = mat.instance_raw(material.1)?;
 
         let set = &instance.set;
 

--- a/nitrogen/src/graph/execution/execute.rs
+++ b/nitrogen/src/graph/execution/execute.rs
@@ -54,9 +54,12 @@ pub(crate) unsafe fn execute(
             // TODO FEARLESS CONCURRENCY!!!
             for pass in &batch.passes {
                 // descriptor set stuff
-                let (_set_layout, _pool, set) = &base_res.pipelines_desc_set[pass];
+                let mat_raw = res.pass_mats.get(pass);
+                let set_raw = mat_raw
+                    .and_then(|hndl| storages.material.raw(hndl.0).map(|mat| (hndl.1, mat)))
+                    .and_then(|(inst, mat)| mat.intance_raw(inst).map(|inst| &inst.set));
 
-                {
+                if let Some(set) = set_raw {
                     let reads = resolved_graph.pass_reads[pass]
                         .iter()
                         .map(|(rid, ty, binding, samp)| match ty {
@@ -266,7 +269,14 @@ pub(crate) unsafe fn execute(
                         raw_cmd.set_viewports(0, &[viewport.clone()]);
                         raw_cmd.set_scissors(0, &[viewport.rect]);
 
-                        raw_cmd.bind_graphics_descriptor_sets(&pipeline.layout, 0, Some(set), &[]);
+                        if let Some(set) = set_raw {
+                            raw_cmd.bind_graphics_descriptor_sets(
+                                &pipeline.layout,
+                                0,
+                                Some(set),
+                                &[],
+                            );
+                        }
 
                         let pass_impl = &graph.passes_gfx_impl[&pass.0];
 
@@ -313,7 +323,14 @@ pub(crate) unsafe fn execute(
 
                         raw_cmd.bind_compute_pipeline(&pipeline.pipeline);
 
-                        raw_cmd.bind_compute_descriptor_sets(&pipeline.layout, 0, Some(set), &[]);
+                        if let Some(set) = set_raw {
+                            raw_cmd.bind_compute_descriptor_sets(
+                                &pipeline.layout,
+                                0,
+                                Some(set),
+                                &[],
+                            );
+                        }
 
                         let pass_impl = &graph.passes_cmpt_impl[&pass.0];
 

--- a/nitrogen/src/graph/execution/execute.rs
+++ b/nitrogen/src/graph/execution/execute.rs
@@ -57,7 +57,7 @@ pub(crate) unsafe fn execute(
                 let mat_raw = res.pass_mats.get(pass);
                 let set_raw = mat_raw
                     .and_then(|hndl| storages.material.raw(hndl.0).map(|mat| (hndl.1, mat)))
-                    .and_then(|(inst, mat)| mat.intance_raw(inst).map(|inst| &inst.set));
+                    .and_then(|(inst, mat)| mat.instance_raw(inst).map(|inst| &inst.set));
 
                 if let Some(set) = set_raw {
                     let reads = resolved_graph.pass_reads[pass]

--- a/nitrogen/src/graph/execution/mod.rs
+++ b/nitrogen/src/graph/execution/mod.rs
@@ -56,7 +56,9 @@ impl GraphBaseResources {
             .pipeline
             .destroy(res_list, self.pipelines_compute.values());
 
-        // TODO free pass materials
+        for (_, mat) in self.pipelines_mat {
+            res_list.queue_material(mat);
+        }
     }
 }
 

--- a/nitrogen/src/graph/mod.rs
+++ b/nitrogen/src/graph/mod.rs
@@ -285,13 +285,15 @@ impl GraphStorage {
             let (base_resources, usages) = {
                 let passes = &graph.passes[..];
 
-                let base = graph
+                // insert into cache
+                graph
                     .exec_base_resources
                     .entry(*exec_id)
                     .or_insert_with(|| {
                         execution::prepare_base(device, storages, exec, resolved, passes)
                     });
 
+                // now read base again (some kind of reborrowing, need to investigate...)
                 let base = graph.exec_base_resources.get_mut(exec_id)?;
 
                 graph.exec_usages.entry(*exec_id).or_insert_with(|| {

--- a/nitrogen/src/lib.rs
+++ b/nitrogen/src/lib.rs
@@ -313,11 +313,6 @@ impl Context {
         self.material_storage.create(&self.device_ctx, create_infos)
     }
 
-    /// Destroy material objects.
-    pub unsafe fn material_destroy(&mut self, materials: &[material::MaterialHandle]) {
-        self.material_storage.destroy(&self.device_ctx, materials)
-    }
-
     /// Create material instances and retrieve handles for them.
     ///
     /// For more information about material instances, see the [`material` module] documentation.
@@ -329,14 +324,6 @@ impl Context {
     ) -> SmallVec<[Result<material::MaterialInstanceHandle, material::MaterialError>; 16]> {
         self.material_storage
             .create_instances(&self.device_ctx, materials)
-    }
-
-    /// Destroy material instance objects.
-    pub unsafe fn material_destroy_instance(
-        &mut self,
-        instances: &[material::MaterialInstanceHandle],
-    ) {
-        self.material_storage.destroy_instances(instances)
     }
 
     /// Update a material instance with resource handles.
@@ -427,24 +414,6 @@ impl Context {
         graph: graph::GraphHandle,
     ) -> Result<(), Vec<graph::GraphCompileError>> {
         self.graph_storage.compile(graph)
-    }
-
-    /// Retrieve the `ImageHandle` of a graph output resource.
-    pub fn graph_get_output_image<T: Into<graph::ResourceName>>(
-        &self,
-        graph: graph::GraphHandle,
-        image: T,
-    ) -> Option<image::ImageHandle> {
-        self.graph_storage.output_image(graph, image)
-    }
-
-    /// Retrieve the `BufferHandle` of a graph output resource.
-    pub fn graph_get_output_buffer<T: Into<graph::ResourceName>>(
-        &self,
-        graph: graph::GraphHandle,
-        buffer: T,
-    ) -> Option<buffer::BufferHandle> {
-        self.graph_storage.output_buffer(graph, buffer)
     }
 
     // submit group

--- a/nitrogen/src/lib.rs
+++ b/nitrogen/src/lib.rs
@@ -237,9 +237,9 @@ impl Context {
     // image
 
     /// Create image objects and retrieve handles for them.
-    pub unsafe fn image_create(
+    pub unsafe fn image_create<I: Into<gfx::image::Usage> + Clone>(
         &mut self,
-        create_infos: &[image::ImageCreateInfo<image::ImageUsage>],
+        create_infos: &[image::ImageCreateInfo<I>],
     ) -> SmallVec<[image::Result<image::ImageHandle>; 16]> {
         self.image_storage.create(&self.device_ctx, create_infos)
     }

--- a/nitrogen/src/resources/buffer.rs
+++ b/nitrogen/src/resources/buffer.rs
@@ -23,6 +23,7 @@ use crate::submit_group::ResourceList;
 
 pub(crate) type BufferTypeInternal = AllocBuffer;
 
+#[derive(Debug)]
 pub struct Buffer {
     pub(crate) buffer: BufferTypeInternal,
     size: u64,
@@ -157,7 +158,7 @@ impl BufferStorage {
     pub(crate) unsafe fn release(self, device: &DeviceContext) {
         let mut alloc = device.allocator();
 
-        for (_, buffer) in self.buffers.into_iter() {
+        for (_, buffer) in self.buffers {
             alloc.destroy_buffer(&device.device, buffer.buffer);
         }
     }

--- a/nitrogen/src/resources/image.rs
+++ b/nitrogen/src/resources/image.rs
@@ -309,7 +309,7 @@ impl ImageStorage {
     pub(crate) unsafe fn release(self, device: &DeviceContext) {
         let mut alloc = device.allocator();
 
-        for (_, image) in self.storage.into_iter() {
+        for (_, image) in self.storage {
             alloc.destroy_image(&device.device, image.image);
             device.device.destroy_image_view(image.view);
         }

--- a/nitrogen/src/resources/sampler.rs
+++ b/nitrogen/src/resources/sampler.rs
@@ -132,6 +132,7 @@ impl SamplerStorage {
     {
         for handle in handles.into_iter() {
             let handle = *handle.borrow();
+
             match self.storage.remove(handle) {
                 Some(sampler) => {
                     res_list.queue_sampler(sampler);

--- a/nitrogen/src/util/allocator.rs
+++ b/nitrogen/src/util/allocator.rs
@@ -10,6 +10,7 @@ pub(crate) trait Block: Sized {
     fn memory(&self) -> &crate::types::Memory;
 }
 
+#[derive(Debug)]
 pub(crate) struct BufferType<A: Allocator> {
     buffer: crate::types::Buffer,
     block: A::Block,

--- a/nitrogen/src/util/allocator.rs
+++ b/nitrogen/src/util/allocator.rs
@@ -70,6 +70,7 @@ pub enum AllocatorError {
 }
 
 /// An allocation request
+#[derive(Debug)]
 pub(crate) struct Request {
     pub(crate) transient: bool,
     pub(crate) _persistently_mappable: bool,
@@ -79,6 +80,7 @@ pub(crate) struct Request {
     pub(crate) type_mask: u64,
 }
 
+#[derive(Debug)]
 pub(crate) struct BufferRequest {
     pub(crate) transient: bool,
     pub(crate) persistently_mappable: bool,
@@ -87,6 +89,7 @@ pub(crate) struct BufferRequest {
     pub(crate) size: u64,
 }
 
+#[derive(Debug)]
 pub(crate) struct ImageRequest {
     pub(crate) transient: bool,
     pub(crate) properties: gfx::memory::Properties,

--- a/nitrogen/src/util/submit_group.rs
+++ b/nitrogen/src/util/submit_group.rs
@@ -17,6 +17,7 @@ use crate::resources::semaphore_pool::{SemaphoreList, SemaphorePool};
 
 use smallvec::SmallVec;
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 /// `SubmitGroup`s are used to synchronize access to resources and ensure
@@ -43,6 +44,8 @@ pub struct SubmitGroup {
 
     sem_list: SemaphoreList,
     res_destroys: ResourceList,
+
+    graph_resources: HashMap<graph::GraphHandle, graph::GraphResources>,
 }
 
 impl SubmitGroup {
@@ -52,7 +55,6 @@ impl SubmitGroup {
                 .device
                 .create_command_pool_typed(
                     device.graphics_queue_group(),
-                    // gfx::pool::CommandPoolCreateFlags::RESET_INDIVIDUAL,
                     gfx::pool::CommandPoolCreateFlags::empty(),
                 )
                 .unwrap();
@@ -60,7 +62,6 @@ impl SubmitGroup {
                 .device
                 .create_command_pool_typed(
                     device.compute_queue_group(),
-                    // gfx::pool::CommandPoolCreateFlags::RESET_INDIVIDUAL,
                     gfx::pool::CommandPoolCreateFlags::empty(),
                 )
                 .unwrap();
@@ -68,7 +69,6 @@ impl SubmitGroup {
                 .device
                 .create_command_pool_typed(
                     device.transfer_queue_group(),
-                    // gfx::pool::CommandPoolCreateFlags::RESET_INDIVIDUAL,
                     gfx::pool::CommandPoolCreateFlags::empty(),
                 )
                 .unwrap();
@@ -89,6 +89,8 @@ impl SubmitGroup {
             sem_list: SemaphoreList::new(),
 
             res_destroys: ResourceList::new(device),
+
+            graph_resources: HashMap::new(),
         }
     }
 
@@ -119,7 +121,7 @@ impl SubmitGroup {
 
         self.sem_list.advance();
 
-        self.res_destroys.free_resources();
+        self.res_destroys.free_resources(ctx);
 
         self.pool_graphics.reset();
         self.pool_compute.reset();
@@ -170,10 +172,12 @@ impl SubmitGroup {
             buffer: &mut ctx.buffer_storage,
             vertex_attrib: &ctx.vertex_attrib_storage,
             sampler: &mut ctx.sampler_storage,
-            material: &ctx.material_storage,
+            material: &mut ctx.material_storage,
         };
 
-        ctx.graph_storage.execute(
+        let res = self.graph_resources.remove(&graph);
+
+        if let Some(res) = ctx.graph_storage.execute(
             &ctx.device_ctx,
             &mut self.sem_pool,
             &mut self.sem_list,
@@ -183,8 +187,13 @@ impl SubmitGroup {
             &mut storages,
             store,
             graph,
+            res,
             exec_context,
-        )
+        ) {
+            self.graph_resources.insert(graph, res);
+        } else {
+            println!("Weeeeeird!!");
+        }
     }
 
     pub fn graph_destroy<G>(&mut self, ctx: &mut Context, graph: G)
@@ -201,7 +210,7 @@ impl SubmitGroup {
             buffer: &mut ctx.buffer_storage,
             vertex_attrib: &ctx.vertex_attrib_storage,
             sampler: &mut ctx.sampler_storage,
-            material: &ctx.material_storage,
+            material: &mut ctx.material_storage,
         };
 
         for handle in graph.into_iter() {
@@ -210,6 +219,21 @@ impl SubmitGroup {
             ctx.graph_storage
                 .destroy(&mut self.res_destroys, &mut storages, handle);
         }
+    }
+
+    pub fn graph_get_image<I: Into<graph::ResourceName>>(
+        &self,
+        ctx: &Context,
+        graph: graph::GraphHandle,
+        image: I,
+    ) -> Option<image::ImageHandle> {
+        let g = ctx.graph_storage.storage.get(graph)?;
+        let input_num = g.last_input?;
+        let (resolve, _) = g.resolve_cache.get(&input_num)?;
+        let id = resolve.name_lookup.get(&image.into())?;
+
+        let res = self.graph_resources.get(&graph)?;
+        res.images.get(id).cloned()
     }
 
     pub unsafe fn image_upload_data(
@@ -273,6 +297,18 @@ impl SubmitGroup {
             .destroy(&mut self.res_destroys, samplers)
     }
 
+    pub fn material_destroy(&mut self, materials: &[material::MaterialHandle]) {
+        for m in materials {
+            self.res_destroys.queue_material(*m);
+        }
+    }
+
+    pub fn material_instance_destroy(&mut self, instances: &[material::MaterialInstanceHandle]) {
+        for i in instances {
+            self.res_destroys.queue_material_instance(*i);
+        }
+    }
+
     pub unsafe fn release(mut self, ctx: &mut Context) {
         {
             let pool = self.pool_graphics.0.into_impl();
@@ -311,6 +347,9 @@ pub(crate) struct ResourceList {
     pipelines_layout: SmallVec<[types::PipelineLayout; 16]>,
     desc_set_layouts: SmallVec<[types::DescriptorSetLayout; 16]>,
     desc_pools: SmallVec<[types::DescriptorPool; 16]>,
+
+    materials: SmallVec<[material::MaterialHandle; 16]>,
+    material_instances: SmallVec<[material::MaterialInstanceHandle; 16]>,
 }
 
 impl ResourceList {
@@ -328,6 +367,9 @@ impl ResourceList {
             pipelines_layout: SmallVec::new(),
             desc_set_layouts: SmallVec::new(),
             desc_pools: SmallVec::new(),
+
+            materials: SmallVec::new(),
+            material_instances: SmallVec::new(),
         }
     }
 
@@ -375,8 +417,17 @@ impl ResourceList {
         self.desc_pools.push(pool);
     }
 
-    unsafe fn free_resources(&mut self) {
+    pub(crate) fn queue_material(&mut self, mat: material::MaterialHandle) {
+        self.materials.push(mat);
+    }
+
+    pub(crate) fn queue_material_instance(&mut self, mat: material::MaterialInstanceHandle) {
+        self.material_instances.push(mat);
+    }
+
+    unsafe fn free_resources(&mut self, ctx: &mut Context) {
         use crate::util::allocator::Allocator;
+        use gfx::DescriptorPool;
 
         let mut alloc = self.device.allocator();
 
@@ -416,6 +467,14 @@ impl ResourceList {
 
         for layout in self.pipelines_layout.drain() {
             device.destroy_pipeline_layout(layout);
+        }
+
+        for mat in self.materials.drain() {
+            ctx.material_storage.destroy(&ctx.device_ctx, &[mat]);
+        }
+
+        for mat in self.material_instances.drain() {
+            ctx.material_storage.destroy_instances(&[mat]);
         }
 
         for desc_pool in self.desc_pools.drain() {


### PR DESCRIPTION
Big change incoming!

 - more examples use the `MainLoop` helper
 - made descriptors for graph resources (pass creates resource, other pass reads from them) per submit group
 - fixed shutdown sequence, now there shouldn't be anymore crashes upon closing.
