### PR TITLE
remove SmallVec from public API

### DIFF
--- a/examples/2d-squares/main.rs
+++ b/examples/2d-squares/main.rs
@@ -97,7 +97,7 @@ fn init(
                 }],
             }],
         };
-        ctx.vertex_attribs_create(&[create_info]).remove(0)
+        ctx.vertex_attribs_create(create_info)
     };
 
     // create a bunch of buffers

--- a/examples/2d-squares/main.rs
+++ b/examples/2d-squares/main.rs
@@ -140,10 +140,10 @@ fn init(
                 (1, material::MaterialParameterType::StorageBuffer),
             ],
         };
-        ctx.material_create(&[create_info]).remove(0).ok()?
+        ctx.material_create(create_info).ok()?
     };
 
-    let instance_material = unsafe { ctx.material_create_instance(&[material]).remove(0).ok()? };
+    let instance_material = unsafe { ctx.material_create_instance(material).ok()? };
 
     // write to instance
     {

--- a/examples/common/src/resource.rs
+++ b/examples/common/src/resource.rs
@@ -94,7 +94,7 @@ pub unsafe fn image_create(
         usage,
     };
 
-    ctx.image_create(&[create_info]).remove(0).ok()
+    ctx.image_create(create_info).ok()
 }
 
 pub unsafe fn image_create_with_content(
@@ -119,10 +119,7 @@ pub unsafe fn image_create_with_content(
         target_offset: (0, 0, 0),
     };
 
-    submit
-        .image_upload_data(ctx, &[(img, upload)])
-        .remove(0)
-        .ok()?;
+    submit.image_upload_data(ctx, img, upload).ok()?;
 
     let sampler_create = sampler::SamplerCreateInfo {
         min_filter: sampler::Filter::Linear,

--- a/examples/common/src/resource.rs
+++ b/examples/common/src/resource.rs
@@ -132,7 +132,7 @@ pub unsafe fn image_create_with_content(
         ),
     };
 
-    let sampler = ctx.sampler_create(&[sampler_create]).remove(0);
+    let sampler = ctx.sampler_create(sampler_create);
 
     Some((img, sampler))
 }

--- a/examples/common/src/resource.rs
+++ b/examples/common/src/resource.rs
@@ -22,9 +22,7 @@ pub unsafe fn buffer_device_local_create<T: Sized>(
             is_transient: false,
         };
 
-        ctx.buffer_device_local_create(&[create_info])
-            .remove(0)
-            .ok()?
+        ctx.buffer_device_local_create(create_info).ok()?
     };
 
     // upload
@@ -32,8 +30,7 @@ pub unsafe fn buffer_device_local_create<T: Sized>(
         let upload_info = buffer::BufferUploadInfo { offset: 0, data };
 
         submit
-            .buffer_device_local_upload(ctx, &[(buffer, upload_info)])
-            .remove(0)
+            .buffer_device_local_upload(ctx, buffer, upload_info)
             .ok()?;
     }
 

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -21,7 +21,7 @@ fn main() {
         let create_info = material::MaterialCreateInfo {
             parameters: &[(0, material::MaterialParameterType::StorageBuffer)],
         };
-        unsafe { ctx.material_create(&[create_info]).remove(0).unwrap() }
+        unsafe { ctx.material_create(create_info).unwrap() }
     };
 
     let buffer = {
@@ -43,11 +43,7 @@ fn main() {
                 | buffer::BufferUsage::UNIFORM,
         };
 
-        let buffer = unsafe {
-            ctx.buffer_cpu_visible_create(&[create_info])
-                .remove(0)
-                .unwrap()
-        };
+        let buffer = unsafe { ctx.buffer_cpu_visible_create(create_info).unwrap() };
 
         let upload_data = buffer::BufferUploadInfo {
             offset: 0,
@@ -56,8 +52,7 @@ fn main() {
 
         unsafe {
             submit
-                .buffer_cpu_visible_upload(&mut ctx, &[(buffer, upload_data)])
-                .remove(0)
+                .buffer_cpu_visible_upload(&mut ctx, buffer, upload_data)
                 .unwrap();
 
             submit.wait(&mut ctx);
@@ -66,7 +61,7 @@ fn main() {
         buffer
     };
 
-    let material_instance = unsafe { ctx.material_create_instance(&[material]).remove(0).unwrap() };
+    let material_instance = unsafe { ctx.material_create_instance(material).unwrap() };
 
     unsafe {
         ctx.material_write_instance(

--- a/examples/model/main.rs
+++ b/examples/model/main.rs
@@ -110,7 +110,7 @@ fn init_resources(
                 },
             ],
         };
-        ctx.vertex_attribs_create(&[create_info]).remove(0)
+        ctx.vertex_attribs_create(create_info)
     };
 
     let graph = create_graph(

--- a/examples/multi-target/main.rs
+++ b/examples/multi-target/main.rs
@@ -136,11 +136,10 @@ fn init(
             ],
         };
 
-        ctx.material_create(&[create_info]).remove(0)
-    }
-    .unwrap();
+        ctx.material_create(create_info).unwrap()
+    };
 
-    let mat_instance = unsafe { ctx.material_create_instance(&[material]).remove(0) }.unwrap();
+    let mat_instance = unsafe { ctx.material_create_instance(material) }.unwrap();
 
     unsafe {
         ctx.material_write_instance(

--- a/examples/multi-target/main.rs
+++ b/examples/multi-target/main.rs
@@ -123,7 +123,7 @@ fn init(
             ],
         };
 
-        ctx.vertex_attribs_create(&[info]).remove(0)
+        ctx.vertex_attribs_create(info)
     };
 
     // create material and material instance

--- a/examples/two-pass/main.rs
+++ b/examples/two-pass/main.rs
@@ -109,7 +109,7 @@ fn main() {
                 wrap_mode: (WrapMode::Clamp, WrapMode::Clamp, WrapMode::Clamp),
             };
 
-            ntg.sampler_create(&[sampler_create]).remove(0)
+            ntg.sampler_create(sampler_create)
         };
 
         (img, sampler)
@@ -195,7 +195,7 @@ fn main() {
             ],
         };
 
-        ntg.vertex_attribs_create(&[info]).remove(0)
+        ntg.vertex_attribs_create(info)
     };
 
     let graph = setup_graphs(

--- a/examples/two-pass/main.rs
+++ b/examples/two-pass/main.rs
@@ -82,7 +82,7 @@ fn main() {
             ..Default::default()
         };
 
-        let img = unsafe { ntg.image_create(&[create_info]).remove(0).unwrap() };
+        let img = unsafe { ntg.image_create(create_info).unwrap() };
 
         debug!("width {}, height {}", width, height);
 
@@ -94,10 +94,7 @@ fn main() {
                 target_offset: (0, 0, 0),
             };
 
-            submit
-                .image_upload_data(&mut ntg, &[(img, data)])
-                .remove(0)
-                .unwrap()
+            submit.image_upload_data(&mut ntg, img, data).unwrap()
         }
 
         drop(image);

--- a/examples/two-pass/main.rs
+++ b/examples/two-pass/main.rs
@@ -48,11 +48,10 @@ fn main() {
             ],
         };
 
-        ntg.material_create(&[create_info]).remove(0).unwrap()
+        ntg.material_create(create_info).unwrap()
     };
 
-    let mat_example_instance =
-        unsafe { ntg.material_create_instance(&[material]).remove(0).unwrap() };
+    let mat_example_instance = unsafe { ntg.material_create_instance(material).unwrap() };
 
     let (image, sampler) = {
         let image_data = include_bytes!("assets/test.png");
@@ -126,10 +125,7 @@ fn main() {
             usage: nitrogen::buffer::BufferUsage::TRANSFER_SRC
                 | nitrogen::buffer::BufferUsage::VERTEX,
         };
-        let buffer = ntg
-            .buffer_cpu_visible_create(&[create_info])
-            .remove(0)
-            .unwrap();
+        let buffer = ntg.buffer_cpu_visible_create(create_info).unwrap();
 
         let upload_data = nitrogen::buffer::BufferUploadInfo {
             offset: 0,
@@ -137,8 +133,7 @@ fn main() {
         };
 
         submit
-            .buffer_cpu_visible_upload(&mut ntg, &[(buffer, upload_data)])
-            .remove(0)
+            .buffer_cpu_visible_upload(&mut ntg, buffer, upload_data)
             .unwrap();
 
         buffer
@@ -151,10 +146,7 @@ fn main() {
             usage: nitrogen::buffer::BufferUsage::TRANSFER_SRC
                 | nitrogen::buffer::BufferUsage::VERTEX,
         };
-        let buffer = ntg
-            .buffer_cpu_visible_create(&[create_info])
-            .remove(0)
-            .unwrap();
+        let buffer = ntg.buffer_cpu_visible_create(create_info).unwrap();
 
         let upload_data = nitrogen::buffer::BufferUploadInfo {
             offset: 0,
@@ -162,8 +154,7 @@ fn main() {
         };
 
         submit
-            .buffer_cpu_visible_upload(&mut ntg, &[(buffer, upload_data)])
-            .remove(0)
+            .buffer_cpu_visible_upload(&mut ntg, buffer, upload_data)
             .unwrap();
 
         buffer
@@ -226,10 +217,7 @@ fn main() {
             usage: nitrogen::buffer::BufferUsage::TRANSFER_SRC
                 | nitrogen::buffer::BufferUsage::UNIFORM,
         };
-        let buffer = ntg
-            .buffer_cpu_visible_create(&[create_info])
-            .remove(0)
-            .unwrap();
+        let buffer = ntg.buffer_cpu_visible_create(create_info).unwrap();
 
         let upload_data = nitrogen::buffer::BufferUploadInfo {
             offset: 0,
@@ -237,8 +225,7 @@ fn main() {
         };
 
         submit
-            .buffer_cpu_visible_upload(&mut ntg, &[(buffer, upload_data)])
-            .remove(0)
+            .buffer_cpu_visible_upload(&mut ntg, buffer, upload_data)
             .unwrap();
 
         buffer

--- a/nitrogen/src/graph/execution/prepare.rs
+++ b/nitrogen/src/graph/execution/prepare.rs
@@ -136,11 +136,7 @@ pub(crate) unsafe fn prepare(
             let info = &passes[pass.0].1;
 
             if let Some(mat) = base.pipelines_mat.get(pass) {
-                let instance = storages
-                    .material
-                    .create_instances(device, &[*mat])
-                    .remove(0)
-                    .unwrap();
+                let instance = storages.material.create_instance(device, *mat).unwrap();
 
                 res.pass_mats.insert(*pass, instance);
             }
@@ -459,11 +455,7 @@ unsafe fn create_render_pass(
         dependencies: &[dependencies],
     };
 
-    storages
-        .render_pass
-        .create(device, &[create_info])
-        .remove(0)
-        .ok()
+    storages.render_pass.create(device, create_info).ok()
 }
 
 unsafe fn create_pipeline_compute(
@@ -742,8 +734,7 @@ unsafe fn create_resource(
 
                     storages
                         .buffer
-                        .device_local_create(device, &[create_info])
-                        .remove(0)
+                        .device_local_create(device, create_info)
                         .ok()?
                 }
                 BufferStorageType::HostVisible => {
@@ -755,8 +746,7 @@ unsafe fn create_resource(
 
                     storages
                         .buffer
-                        .cpu_visible_create(device, &[create_info])
-                        .remove(0)
+                        .cpu_visible_create(device, create_info)
                         .ok()?
                 }
             };

--- a/nitrogen/src/graph/execution/prepare.rs
+++ b/nitrogen/src/graph/execution/prepare.rs
@@ -630,11 +630,7 @@ unsafe fn create_resource(
                 is_transient: false,
             };
 
-            let img_handle = storages
-                .image
-                .create(device, &[create_info])
-                .remove(0)
-                .ok()?;
+            let img_handle = storages.image.create(device, create_info).ok()?;
 
             res.images.insert(id, img_handle);
             res.external_resources.insert(id);
@@ -713,11 +709,7 @@ unsafe fn create_resource(
                 is_transient: false,
             };
 
-            let img_handle = storages
-                .image
-                .create(device, &[create_info])
-                .remove(0)
-                .ok()?;
+            let img_handle = storages.image.create(device, create_info).ok()?;
 
             res.images.insert(id, img_handle);
 

--- a/nitrogen/src/graph/execution/prepare.rs
+++ b/nitrogen/src/graph/execution/prepare.rs
@@ -497,8 +497,7 @@ unsafe fn create_pipeline_compute(
 
     let pipeline_handle = storages
         .pipeline
-        .create_compute_pipelines(device, &[create_info])
-        .remove(0)
+        .create_compute_pipeline(device, create_info)
         .ok();
 
     pipeline_handle.map(|handle| (handle, pass_mat))
@@ -552,14 +551,13 @@ unsafe fn create_pipeline_graphics(
 
     let pipeline_handle = storages
         .pipeline
-        .create_graphics_pipelines(
+        .create_graphics_pipeline(
             device,
             storages.render_pass,
             storages.vertex_attrib,
             render_pass,
-            &[create_info],
+            create_info,
         )
-        .remove(0)
         .ok();
 
     pipeline_handle.map(|handle| (handle, pass_mat))
@@ -640,22 +638,19 @@ unsafe fn create_resource(
             // If the image is used for sampling then it means some other pass will read from it
             // as a color image. In that case we create a sampler for this image as well
             if usages.0.contains(gfx::image::Usage::SAMPLED) {
-                let sampler = storages
-                    .sampler
-                    .create(
-                        device,
-                        &[sampler::SamplerCreateInfo {
-                            min_filter: sampler::Filter::Linear,
-                            mip_filter: sampler::Filter::Linear,
-                            mag_filter: sampler::Filter::Linear,
-                            wrap_mode: (
-                                sampler::WrapMode::Clamp,
-                                sampler::WrapMode::Clamp,
-                                sampler::WrapMode::Clamp,
-                            ),
-                        }],
-                    )
-                    .remove(0);
+                let sampler = storages.sampler.create(
+                    device,
+                    sampler::SamplerCreateInfo {
+                        min_filter: sampler::Filter::Linear,
+                        mip_filter: sampler::Filter::Linear,
+                        mag_filter: sampler::Filter::Linear,
+                        wrap_mode: (
+                            sampler::WrapMode::Clamp,
+                            sampler::WrapMode::Clamp,
+                            sampler::WrapMode::Clamp,
+                        ),
+                    },
+                );
                 res.samplers.insert(id, sampler);
                 backbuffer.samplers.insert(name.clone(), sampler);
             }
@@ -716,22 +711,19 @@ unsafe fn create_resource(
             // If the image is used for sampling then it means some other pass will read from it
             // as a color image. In that case we create a sampler for this image as well
             if usages.0.contains(gfx::image::Usage::SAMPLED) {
-                let sampler = storages
-                    .sampler
-                    .create(
-                        device,
-                        &[sampler::SamplerCreateInfo {
-                            min_filter: sampler::Filter::Linear,
-                            mip_filter: sampler::Filter::Linear,
-                            mag_filter: sampler::Filter::Linear,
-                            wrap_mode: (
-                                sampler::WrapMode::Clamp,
-                                sampler::WrapMode::Clamp,
-                                sampler::WrapMode::Clamp,
-                            ),
-                        }],
-                    )
-                    .remove(0);
+                let sampler = storages.sampler.create(
+                    device,
+                    sampler::SamplerCreateInfo {
+                        min_filter: sampler::Filter::Linear,
+                        mip_filter: sampler::Filter::Linear,
+                        mag_filter: sampler::Filter::Linear,
+                        wrap_mode: (
+                            sampler::WrapMode::Clamp,
+                            sampler::WrapMode::Clamp,
+                            sampler::WrapMode::Clamp,
+                        ),
+                    },
+                );
                 res.samplers.insert(id, sampler);
             }
 

--- a/nitrogen/src/lib.rs
+++ b/nitrogen/src/lib.rs
@@ -258,9 +258,9 @@ impl Context {
     /// Create sampler objects and retrieve handles for them.
     pub unsafe fn sampler_create(
         &mut self,
-        create_infos: &[sampler::SamplerCreateInfo],
-    ) -> SmallVec<[sampler::SamplerHandle; 16]> {
-        self.sampler_storage.create(&self.device_ctx, create_infos)
+        create_info: sampler::SamplerCreateInfo,
+    ) -> sampler::SamplerHandle {
+        self.sampler_storage.create(&self.device_ctx, create_info)
     }
 
     // buffer
@@ -298,9 +298,9 @@ impl Context {
     /// [`GraphicsPassInfo`]: ./graph/pass/struct.GraphicsPassInfo.html
     pub fn vertex_attribs_create(
         &mut self,
-        infos: &[vertex_attrib::VertexAttribInfo],
-    ) -> SmallVec<[vertex_attrib::VertexAttribHandle; 16]> {
-        self.vertex_attrib_storage.create(infos)
+        info: vertex_attrib::VertexAttribInfo,
+    ) -> vertex_attrib::VertexAttribHandle {
+        self.vertex_attrib_storage.create(info)
     }
 
     /// Destroy vertex attribute description objects.

--- a/nitrogen/src/lib.rs
+++ b/nitrogen/src/lib.rs
@@ -48,9 +48,8 @@
 //!
 //! [`Context`]: ./struct.Context.html
 
-// extern crate gfx_backend_vulkan as back;
-// pub extern crate gfx_hal as gfx;
-// extern crate gfx_memory as gfxm;
+#[macro_use]
+extern crate derive_more;
 
 pub use gfx;
 

--- a/nitrogen/src/lib.rs
+++ b/nitrogen/src/lib.rs
@@ -248,9 +248,9 @@ impl Context {
     /// Create image objects and retrieve handles for them.
     pub unsafe fn image_create<I: Into<gfx::image::Usage> + Clone>(
         &mut self,
-        create_infos: &[image::ImageCreateInfo<I>],
-    ) -> SmallVec<[image::Result<image::ImageHandle>; 16]> {
-        self.image_storage.create(&self.device_ctx, create_infos)
+        create_info: image::ImageCreateInfo<I>,
+    ) -> image::Result<image::ImageHandle> {
+        self.image_storage.create(&self.device_ctx, create_info)
     }
 
     // sampler

--- a/nitrogen/src/lib.rs
+++ b/nitrogen/src/lib.rs
@@ -54,8 +54,6 @@
 
 pub use gfx;
 
-use smallvec::SmallVec;
-
 pub(crate) mod types;
 
 pub mod display;
@@ -268,24 +266,24 @@ impl Context {
     /// Create buffer objects and retrieve handles for them.
     pub unsafe fn buffer_cpu_visible_create<U>(
         &mut self,
-        create_infos: &[buffer::CpuVisibleCreateInfo<U>],
-    ) -> SmallVec<[buffer::Result<buffer::BufferHandle>; 16]>
+        create_info: buffer::CpuVisibleCreateInfo<U>,
+    ) -> buffer::Result<buffer::BufferHandle>
     where
         U: Into<gfx::buffer::Usage> + Clone,
     {
         self.buffer_storage
-            .cpu_visible_create(&self.device_ctx, create_infos)
+            .cpu_visible_create(&self.device_ctx, create_info)
     }
 
     pub unsafe fn buffer_device_local_create<U>(
         &mut self,
-        create_infos: &[buffer::DeviceLocalCreateInfo<U>],
-    ) -> SmallVec<[buffer::Result<buffer::BufferHandle>; 16]>
+        create_info: buffer::DeviceLocalCreateInfo<U>,
+    ) -> buffer::Result<buffer::BufferHandle>
     where
         U: Into<gfx::buffer::Usage> + Clone,
     {
         self.buffer_storage
-            .device_local_create(&self.device_ctx, create_infos)
+            .device_local_create(&self.device_ctx, create_info)
     }
 
     // vertex attribs
@@ -317,9 +315,9 @@ impl Context {
     /// [`material` module]: ./resources/material/index.html
     pub unsafe fn material_create(
         &mut self,
-        create_infos: &[material::MaterialCreateInfo],
-    ) -> SmallVec<[Result<material::MaterialHandle, material::MaterialError>; 16]> {
-        self.material_storage.create(&self.device_ctx, create_infos)
+        create_info: material::MaterialCreateInfo,
+    ) -> Result<material::MaterialHandle, material::MaterialError> {
+        self.material_storage.create(&self.device_ctx, create_info)
     }
 
     /// Create material instances and retrieve handles for them.
@@ -329,10 +327,10 @@ impl Context {
     /// [`material` module]: ./resources/material/index.html
     pub unsafe fn material_create_instance(
         &mut self,
-        materials: &[material::MaterialHandle],
-    ) -> SmallVec<[Result<material::MaterialInstanceHandle, material::MaterialError>; 16]> {
+        material: material::MaterialHandle,
+    ) -> Result<material::MaterialInstanceHandle, material::MaterialError> {
         self.material_storage
-            .create_instances(&self.device_ctx, materials)
+            .create_instance(&self.device_ctx, material)
     }
 
     /// Update a material instance with resource handles.

--- a/nitrogen/src/resources/buffer.rs
+++ b/nitrogen/src/resources/buffer.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use bitflags::bitflags;
-use derive_more::{Display, From};
 
 use std;
 use std::borrow::Borrow;

--- a/nitrogen/src/resources/buffer.rs
+++ b/nitrogen/src/resources/buffer.rs
@@ -14,8 +14,6 @@ use crate::device::DeviceContext;
 use crate::util::allocator::{Allocator, AllocatorError, Buffer as AllocBuffer, BufferRequest};
 use crate::util::storage::{Handle, Storage};
 
-use smallvec::SmallVec;
-
 use crate::resources::command_pool::CommandPoolTransfer;
 use crate::resources::semaphore_pool::SemaphoreList;
 use crate::resources::semaphore_pool::SemaphorePool;
@@ -161,114 +159,76 @@ impl BufferStorage {
         self.buffers.get(handle)
     }
 
-    pub(crate) unsafe fn cpu_visible_create<I, U>(
+    pub(crate) unsafe fn cpu_visible_create<U>(
         &mut self,
         device: &DeviceContext,
-        create_infos: I,
-    ) -> SmallVec<[Result<BufferHandle>; 16]>
+        create_info: CpuVisibleCreateInfo<U>,
+    ) -> Result<BufferHandle>
     where
-        I: IntoIterator,
-        I::Item: std::borrow::Borrow<CpuVisibleCreateInfo<U>>,
         U: Clone,
         U: Into<gfx::buffer::Usage>,
     {
         use gfx::memory::Properties;
 
-        let mut results = SmallVec::new();
-
         let mut allocator = device.allocator();
 
-        for create_info in create_infos.into_iter() {
-            let create_info = create_info.borrow();
+        let props = Properties::CPU_VISIBLE | Properties::COHERENT;
+        let usage = create_info.usage.clone().into();
 
-            let props = Properties::CPU_VISIBLE | Properties::COHERENT;
-            let usage = create_info.usage.clone().into();
+        // size should be a multiple of the non-coherent-atom-size
+        let size = {
+            let inv_pad = create_info.size % (self.atom_size as u64);
+            if inv_pad != 0 {
+                create_info.size + (self.atom_size as u64 - inv_pad)
+            } else {
+                create_info.size
+            }
+        };
 
-            // size should be a multiple of the non-coherent-atom-size
-            let size = {
-                let inv_pad = create_info.size % (self.atom_size as u64);
-                if inv_pad != 0 {
-                    create_info.size + (self.atom_size as u64 - inv_pad)
-                } else {
-                    create_info.size
-                }
-            };
+        let req = BufferRequest {
+            transient: create_info.is_transient,
+            // TODO handle mapping??
+            persistently_mappable: false,
+            properties: props,
+            usage,
+            size,
+        };
 
-            let req = BufferRequest {
-                transient: create_info.is_transient,
-                // TODO handle mapping??
-                persistently_mappable: false,
-                properties: props,
-                usage,
-                size,
-            };
+        let raw_buffer = allocator.create_buffer(&device.device, req)?;
 
-            let raw_buffer = match allocator.create_buffer(&device.device, req) {
-                Ok(buf) => buf,
-                Err(err) => {
-                    results.push(Err(err.into()));
-                    continue;
-                }
-            };
+        let buffer = Buffer {
+            size,
+            buffer: raw_buffer,
+            _properties: props,
+            _usage: usage,
+        };
 
-            let buffer = Buffer {
-                size,
-                buffer: raw_buffer,
-                _properties: props,
-                _usage: usage,
-            };
-
-            let handle = self.buffers.insert(buffer);
-            self.cpu_visible.insert(handle.0);
-
-            results.push(Ok(handle));
-        }
-
-        results
+        let handle = self.buffers.insert(buffer);
+        self.cpu_visible.insert(handle.0);
+        Ok(handle)
     }
 
-    pub(crate) unsafe fn cpu_visible_upload<'a, I, T>(
+    pub(crate) unsafe fn cpu_visible_upload<'a, T>(
         &self,
         device: &DeviceContext,
-        uploads: I,
-    ) -> SmallVec<[Result<()>; 16]>
-    where
-        T: 'a,
-        I: IntoIterator,
-        I::Item: std::borrow::Borrow<(BufferHandle, BufferUploadInfo<'a, T>)>,
-    {
-        let mut results = SmallVec::new();
-
-        for upload in uploads.into_iter() {
-            let (buffer, info) = upload.borrow();
-
-            if !self.cpu_visible.contains(&buffer.0) {
-                results.push(Err(BufferError::HandleInvalid));
-                continue;
-            }
-
-            let buffer = match self.raw(*buffer) {
-                Some(buf) => buf,
-                None => {
-                    results.push(Err(BufferError::HandleInvalid));
-                    continue;
-                }
-            };
-
-            let u8_data = to_u8_slice(info.data);
-
-            let upload_fits = info.offset + u8_data.len() as u64 <= buffer.size;
-
-            let res = if upload_fits {
-                write_data_to_buffer(device, &buffer.buffer, info.offset, u8_data).into()
-            } else {
-                Err(BufferError::UploadOutOfBounds)
-            };
-
-            results.push(res);
+        buffer: BufferHandle,
+        info: BufferUploadInfo<'a, T>,
+    ) -> Result<()> {
+        if !self.cpu_visible.contains(&buffer.0) {
+            return Err(BufferError::HandleInvalid);
         }
 
-        results
+        let buffer = self.raw(buffer).ok_or(BufferError::HandleInvalid)?;
+
+        let u8_data = to_u8_slice(info.data);
+
+        let upload_fits = info.offset + u8_data.len() as u64 <= buffer.size;
+
+        if upload_fits {
+            write_data_to_buffer(device, &buffer.buffer, info.offset, u8_data).into()
+        } else {
+            Err(BufferError::UploadOutOfBounds)
+        }
     }
 
     pub(crate) unsafe fn cpu_visible_read<T: Sized>(
@@ -288,183 +248,116 @@ impl BufferStorage {
         Some(())
     }
 
-    pub(crate) unsafe fn device_local_create<I, U>(
+    pub(crate) unsafe fn device_local_create<U>(
         &mut self,
         device: &DeviceContext,
-        create_infos: I,
-    ) -> SmallVec<[Result<BufferHandle>; 16]>
+        create_info: DeviceLocalCreateInfo<U>,
+    ) -> Result<BufferHandle>
     where
-        I: IntoIterator,
-        I::Item: std::borrow::Borrow<DeviceLocalCreateInfo<U>>,
         U: Clone,
         U: Into<gfx::buffer::Usage>,
     {
         use gfx::memory::Properties;
 
-        let mut results = SmallVec::new();
-
         let mut allocator = device.allocator();
 
-        for create_info in create_infos.into_iter() {
-            let create_info = create_info.borrow();
+        let props = Properties::DEVICE_LOCAL;
+        let usage = create_info.usage.clone().into();
 
-            let props = Properties::DEVICE_LOCAL;
-            let usage = create_info.usage.clone().into();
+        // size should be a multiple of the non-coherent-atom-size
+        let size = {
+            let inv_pad = create_info.size % (self.atom_size as u64);
+            if inv_pad != 0 {
+                create_info.size + (self.atom_size as u64 - inv_pad)
+            } else {
+                create_info.size
+            }
+        };
 
-            // size should be a multiple of the non-coherent-atom-size
-            let size = {
-                let inv_pad = create_info.size % (self.atom_size as u64);
-                if inv_pad != 0 {
-                    create_info.size + (self.atom_size as u64 - inv_pad)
-                } else {
-                    create_info.size
-                }
-            };
+        let req = BufferRequest {
+            transient: create_info.is_transient,
+            // TODO handle mapping
+            persistently_mappable: false,
+            properties: props,
+            usage,
+            size,
+        };
 
-            let req = BufferRequest {
-                transient: create_info.is_transient,
-                // TODO handle mapping
-                persistently_mappable: false,
-                properties: props,
-                usage,
-                size,
-            };
+        let raw_buffer = allocator.create_buffer(&device.device, req)?;
 
-            let raw_buffer = match allocator.create_buffer(&device.device, req) {
-                Ok(buf) => buf,
-                Err(err) => {
-                    results.push(Err(err.into()));
-                    continue;
-                }
-            };
+        let buffer = Buffer {
+            size,
+            buffer: raw_buffer,
+            _properties: props,
+            _usage: usage,
+        };
 
-            let buffer = Buffer {
-                size,
-                buffer: raw_buffer,
-                _properties: props,
-                _usage: usage,
-            };
+        let handle = self.buffers.insert(buffer);
+        self.device_local.insert(handle.0);
 
-            let handle = self.buffers.insert(buffer);
-            self.device_local.insert(handle.0);
-
-            results.push(Ok(handle));
-        }
-
-        results
+        Ok(handle)
     }
 
-    pub(crate) unsafe fn device_local_upload<'a, I, T>(
+    pub(crate) unsafe fn device_local_upload<'a, T>(
         &self,
         device: &DeviceContext,
         sem_pool: &SemaphorePool,
         sem_list: &mut SemaphoreList,
         cmd_pool: &CommandPoolTransfer,
         res_list: &mut ResourceList,
-        uploads: I,
-    ) -> SmallVec<[Result<()>; 16]>
-    where
-        T: 'a,
-        I: IntoIterator,
-        I::Item: std::borrow::Borrow<(BufferHandle, BufferUploadInfo<'a, T>)>,
-        I::Item: Clone,
-    {
+        buffer: BufferHandle,
+        info: BufferUploadInfo<'a, T>,
+    ) -> Result<()> {
         use gfx::buffer::Usage;
         use gfx::memory::Properties;
 
-        let mut results = SmallVec::new();
-
-        let mut staging_buffers = SmallVec::<[_; 16]>::new();
-
-        let mut transfers = SmallVec::<[_; 16]>::new();
-
         let mut alloc = device.allocator();
-        for upload in uploads.into_iter() {
-            let (buffer, info) = upload.borrow();
 
-            if !self.device_local.contains(&buffer.0) {
-                results.push(Err(BufferError::HandleInvalid));
-                continue;
-            }
-
-            let buffer = match self.raw(*buffer) {
-                None => {
-                    results.push(Err(BufferError::HandleInvalid));
-                    continue;
-                }
-                Some(buf) => buf,
-            };
-
-            let u8_slice = to_u8_slice(info.data);
-
-            let upload_fits = info.offset + u8_slice.len() as u64 <= buffer.size;
-
-            if !upload_fits {
-                results.push(Err(BufferError::UploadOutOfBounds));
-                continue;
-            }
-
-            let req = BufferRequest {
-                transient: true,
-                // TODO handle mapping
-                persistently_mappable: false,
-                properties: Properties::CPU_VISIBLE | Properties::COHERENT,
-                usage: Usage::TRANSFER_SRC | Usage::TRANSFER_DST,
-                size: u8_slice.len() as u64,
-            };
-
-            let staging_res = alloc.create_buffer(&device.device, req);
-
-            let staging_buffer = match staging_res {
-                Err(err) => {
-                    results.push(Err(err.into()));
-                    continue;
-                }
-                Ok(buffer) => buffer,
-            };
-
-            // write to staging buffer
-
-            match write_data_to_buffer(device, &staging_buffer, 0, u8_slice) {
-                Err(err) => {
-                    results.push(Err(err.into()));
-                    continue;
-                }
-                Ok(_) => {}
-            };
-
-            results.push(Ok(()));
-
-            staging_buffers.push(staging_buffer);
-
-            transfers.push((upload, u8_slice));
+        if !self.device_local.contains(&buffer.0) {
+            return Err(BufferError::HandleInvalid);
         }
+
+        let buffer = self.raw(buffer).ok_or(BufferError::HandleInvalid)?;
+
+        let u8_slice = to_u8_slice(info.data);
+
+        let upload_fits = info.offset + u8_slice.len() as u64 <= buffer.size;
+
+        if !upload_fits {
+            return Err(BufferError::UploadOutOfBounds);
+        }
+
+        let req = BufferRequest {
+            transient: true,
+            // TODO handle mapping
+            persistently_mappable: false,
+            properties: Properties::CPU_VISIBLE | Properties::COHERENT,
+            usage: Usage::TRANSFER_SRC | Usage::TRANSFER_DST,
+            size: u8_slice.len() as u64,
+        };
+
+        let staging_buffer = alloc.create_buffer(&device.device, req)?;
+
+        // write to staging buffer
+
+        write_data_to_buffer(device, &staging_buffer, 0, u8_slice)?;
 
         crate::transfer::copy_buffers(
             device,
             sem_pool,
             sem_list,
             cmd_pool,
-            transfers.as_slice().iter().zip(staging_buffers.iter()).map(
-                |((upload, u8_slice), staging_buf)| {
-                    let (buf, info) = upload.borrow();
-                    let buf = self.raw(*buf).unwrap();
-
-                    crate::transfer::BufferTransfer {
-                        src: staging_buf,
-                        dst: &buf.buffer,
-                        offset: info.offset,
-                        data: *u8_slice,
-                    }
-                },
-            ),
+            &[crate::transfer::BufferTransfer {
+                src: &staging_buffer,
+                dst: &buffer.buffer,
+                offset: info.offset,
+                data: u8_slice,
+            }],
         );
 
-        staging_buffers.into_iter().for_each(|buf| {
-            res_list.queue_buffer(buf);
-        });
+        res_list.queue_buffer(staging_buffer);
 
-        results
+        Ok(())
     }
 
     pub fn destroy<B>(&mut self, res_list: &mut ResourceList, buffers: B)

--- a/nitrogen/src/resources/image.rs
+++ b/nitrogen/src/resources/image.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use derive_more::{Display, From};
-
 use gfx::image;
 use gfx::Device;
 

--- a/nitrogen/src/resources/image.rs
+++ b/nitrogen/src/resources/image.rs
@@ -12,9 +12,6 @@ use std::borrow::Borrow;
 use std::collections::BTreeSet;
 use std::hash::{Hash, Hasher};
 
-use smallvec::smallvec;
-use smallvec::SmallVec;
-
 use crate::util::allocator::{
     Allocator, AllocatorError, BufferRequest, Image as AllocImage, ImageRequest,
 };
@@ -26,7 +23,6 @@ use crate::resources::command_pool::CommandPoolTransfer;
 use crate::resources::semaphore_pool::SemaphoreList;
 use crate::resources::semaphore_pool::SemaphorePool;
 use crate::submit_group::ResourceList;
-use crate::util::allocator::AllocatorError::ImageCreationError;
 
 #[derive(Copy, Clone, Debug)]
 pub enum ImageDimension {

--- a/nitrogen/src/resources/material.rs
+++ b/nitrogen/src/resources/material.rs
@@ -12,7 +12,7 @@ use crate::resources::sampler::{SamplerHandle, SamplerStorage};
 
 use crate::types;
 
-use smallvec::{smallvec, SmallVec};
+use smallvec::SmallVec;
 
 use derive_more::{Display, From};
 
@@ -119,60 +119,46 @@ impl MaterialStorage {
     pub(crate) unsafe fn create(
         &mut self,
         device: &DeviceContext,
-        create_infos: &[MaterialCreateInfo],
-    ) -> SmallVec<[Result<MaterialHandle, MaterialError>; 16]> {
+        create_info: MaterialCreateInfo,
+    ) -> Result<MaterialHandle, MaterialError> {
         use gfx::Device;
 
-        let mut results = smallvec![];
+        let descriptors = create_info
+            .parameters
+            .iter()
+            .map(
+                |(binding, desc_type)| gfx::pso::DescriptorSetLayoutBinding {
+                    binding: *binding,
+                    ty: desc_type.clone().into(),
+                    count: 1,
+                    stage_flags: gfx::pso::ShaderStageFlags::ALL,
+                    immutable_samplers: false,
+                },
+            )
+            .collect::<SmallVec<[_; 16]>>();
 
-        for create_info in create_infos {
-            let descriptors = create_info
-                .parameters
-                .iter()
-                .map(
-                    |(binding, desc_type)| gfx::pso::DescriptorSetLayoutBinding {
-                        binding: *binding,
-                        ty: desc_type.clone().into(),
-                        count: 1,
-                        stage_flags: gfx::pso::ShaderStageFlags::ALL,
-                        immutable_samplers: false,
-                    },
-                )
-                .collect::<SmallVec<[_; 16]>>();
-
-            if descriptors.len() == 0 {
-                results.push(Err(MaterialError::CreateEmptyMaterial));
-                continue;
-            }
-
-            let res = device
-                .device
-                .create_descriptor_set_layout(descriptors.as_slice(), &[]);
-
-            match res {
-                Ok(set) => {
-                    let mut parameters = create_info.parameters.to_vec();
-                    parameters.sort_by_key(|(binding, _)| *binding);
-
-                    let mat = Material {
-                        sets_per_pool: MAX_SETS_PER_POOL,
-                        parameters,
-                        desc_set_layout: set,
-                        instances: Storage::new(),
-                        pool_allocated: Vec::new(),
-                        pool_used: Vec::new(),
-                        pools: Vec::new(),
-                    };
-                    let handle = self.storage.insert(mat);
-                    results.push(Ok(handle));
-                }
-                Err(err) => {
-                    results.push(Err(err.into()));
-                }
-            }
+        if descriptors.len() == 0 {
+            return Err(MaterialError::CreateEmptyMaterial);
         }
 
-        results
+        let set = device
+            .device
+            .create_descriptor_set_layout(descriptors.as_slice(), &[])?;
+
+        let mut parameters = create_info.parameters.to_vec();
+        parameters.sort_by_key(|(binding, _)| *binding);
+
+        let mat = Material {
+            sets_per_pool: MAX_SETS_PER_POOL,
+            parameters,
+            desc_set_layout: set,
+            instances: Storage::new(),
+            pool_allocated: Vec::new(),
+            pool_used: Vec::new(),
+            pools: Vec::new(),
+        };
+        let handle = self.storage.insert(mat);
+        Ok(handle)
     }
 
     pub(crate) unsafe fn create_raw<P>(
@@ -248,39 +234,19 @@ impl MaterialStorage {
         self.storage.get(material)
     }
 
-    pub(crate) unsafe fn create_instances(
+    pub(crate) unsafe fn create_instance(
         &mut self,
         device: &DeviceContext,
-        materials: &[MaterialHandle],
-    ) -> SmallVec<[Result<MaterialInstanceHandle, MaterialError>; 16]> {
-        let mut results = smallvec![];
+        material: MaterialHandle,
+    ) -> Result<MaterialInstanceHandle, MaterialError> {
+        let mat = self
+            .storage
+            .get_mut(material)
+            .ok_or(MaterialError::InvalidHandle)?;
 
-        for material in materials {
-            let mat_res = self
-                .storage
-                .get_mut(*material)
-                .ok_or(MaterialError::InvalidHandle);
+        let instance = mat.create_instance(device)?;
 
-            let mat = match mat_res {
-                Ok(mat) => mat,
-                Err(err) => {
-                    results.push(Err(err.into()));
-                    continue;
-                }
-            };
-
-            let instance = match mat.create_instance(device) {
-                Ok(inst) => inst,
-                Err(err) => {
-                    results.push(Err(err.into()));
-                    continue;
-                }
-            };
-
-            results.push(Ok((*material, instance)));
-        }
-
-        results
+        Ok((material, instance))
     }
 
     pub(crate) unsafe fn write_instance<I>(

--- a/nitrogen/src/resources/material.rs
+++ b/nitrogen/src/resources/material.rs
@@ -14,8 +14,6 @@ use crate::types;
 
 use smallvec::SmallVec;
 
-use derive_more::{Display, From};
-
 pub type MaterialHandle = Handle<Material>;
 
 const MAX_SETS_PER_POOL: u8 = 16;

--- a/nitrogen/src/resources/pipeline.rs
+++ b/nitrogen/src/resources/pipeline.rs
@@ -20,8 +20,6 @@ use gfx::Device;
 use std::collections::BTreeMap;
 use std::error::Error;
 
-use derive_more::{Display, From};
-
 #[derive(Clone, Debug, From, Display)]
 pub enum PipelineError {
     #[display(fmt = "Creation of pipeline was unsuccessful")]

--- a/nitrogen/src/resources/pipeline.rs
+++ b/nitrogen/src/resources/pipeline.rs
@@ -9,8 +9,6 @@ use crate::graph::{BlendMode, DepthMode};
 use crate::render_pass::{RenderPassHandle, RenderPassStorage};
 use crate::vertex_attrib::{VertexAttribHandle, VertexAttribStorage};
 
-use smallvec::SmallVec;
-
 use crate::types;
 use crate::types::*;
 

--- a/nitrogen/src/resources/pipeline.rs
+++ b/nitrogen/src/resources/pipeline.rs
@@ -104,36 +104,13 @@ impl PipelineStorage {
         }
     }
 
-    pub(crate) unsafe fn create_graphics_pipelines(
+    pub(crate) unsafe fn create_graphics_pipeline(
         &mut self,
         device: &DeviceContext,
         render_pass_storage: &RenderPassStorage,
         vertex_attrib_storage: &VertexAttribStorage,
         render_pass_handle: RenderPassHandle,
-        create_infos: &[GraphicsPipelineCreateInfo],
-    ) -> SmallVec<[Result<PipelineHandle>; 16]> {
-        create_infos
-            .iter()
-            .map(|create_info| {
-                self.create_graphics_pipeline(
-                    device,
-                    render_pass_storage,
-                    vertex_attrib_storage,
-                    render_pass_handle,
-                    create_info,
-                )
-            })
-            .collect()
-    }
-
-    // I'm sorry Mike Acton
-    unsafe fn create_graphics_pipeline(
-        &mut self,
-        device: &DeviceContext,
-        render_pass_storage: &RenderPassStorage,
-        vertex_attrib_storage: &VertexAttribStorage,
-        render_pass_handle: RenderPassHandle,
-        create_info: &GraphicsPipelineCreateInfo,
+        create_info: GraphicsPipelineCreateInfo,
     ) -> Result<PipelineHandle> {
         struct ShaderModules {
             vertex: ShaderModule,
@@ -302,21 +279,10 @@ impl PipelineStorage {
         Ok(handle)
     }
 
-    pub(crate) unsafe fn create_compute_pipelines(
-        &mut self,
-        device: &DeviceContext,
-        create_infos: &[ComputePipelineCreateInfo],
-    ) -> SmallVec<[Result<PipelineHandle>; 16]> {
-        create_infos
-            .iter()
-            .map(|create_info| self.create_compute_pipeline(device, create_info))
-            .collect()
-    }
-
     pub(crate) unsafe fn create_compute_pipeline(
         &mut self,
         device: &DeviceContext,
-        create_info: &ComputePipelineCreateInfo,
+        create_info: ComputePipelineCreateInfo,
     ) -> Result<PipelineHandle> {
         let shader_module = device
             .device

--- a/nitrogen/src/resources/render_pass.rs
+++ b/nitrogen/src/resources/render_pass.rs
@@ -7,7 +7,6 @@ use crate::storage::{Handle, Storage};
 use gfx::Device;
 
 use derive_more::{Display, From};
-use smallvec::SmallVec;
 
 use crate::device::DeviceContext;
 use crate::submit_group::ResourceList;
@@ -46,27 +45,22 @@ impl RenderPassStorage {
     pub(crate) unsafe fn create(
         &mut self,
         device: &DeviceContext,
-        create_infos: &[RenderPassCreateInfo],
-    ) -> SmallVec<[Result<RenderPassHandle>; 16]> {
-        create_infos
-            .iter()
-            .map(|create_info| {
-                let pass = device.device.create_render_pass(
-                    create_info.attachments,
-                    create_info.subpasses,
-                    create_info.dependencies,
-                );
+        create_info: RenderPassCreateInfo,
+    ) -> Result<RenderPassHandle> {
+        let pass = device.device.create_render_pass(
+            create_info.attachments,
+            create_info.subpasses,
+            create_info.dependencies,
+        );
 
-                match pass {
-                    Ok(render_pass) => {
-                        let handle = self.storage.insert(RenderPass { render_pass });
+        match pass {
+            Ok(render_pass) => {
+                let handle = self.storage.insert(RenderPass { render_pass });
 
-                        Ok(handle)
-                    }
-                    Err(e) => Err(e.into()),
-                }
-            })
-            .collect()
+                Ok(handle)
+            }
+            Err(e) => Err(e.into()),
+        }
     }
 
     pub(crate) fn raw(&self, handle: RenderPassHandle) -> Option<&crate::types::RenderPass> {

--- a/nitrogen/src/resources/render_pass.rs
+++ b/nitrogen/src/resources/render_pass.rs
@@ -6,8 +6,6 @@ use crate::storage::{Handle, Storage};
 
 use gfx::Device;
 
-use derive_more::{Display, From};
-
 use crate::device::DeviceContext;
 use crate::submit_group::ResourceList;
 

--- a/nitrogen/src/resources/sampler.rs
+++ b/nitrogen/src/resources/sampler.rs
@@ -10,8 +10,6 @@ use crate::device::DeviceContext;
 use crate::util::storage;
 use crate::util::storage::Storage;
 
-use smallvec::SmallVec;
-
 use crate::submit_group::ResourceList;
 use crate::types::Sampler;
 

--- a/nitrogen/src/resources/sampler.rs
+++ b/nitrogen/src/resources/sampler.rs
@@ -101,26 +101,18 @@ impl SamplerStorage {
     pub(crate) unsafe fn create(
         &mut self,
         device: &DeviceContext,
-        create_infos: &[SamplerCreateInfo],
-    ) -> SmallVec<[SamplerHandle; 16]> {
-        let mut results = SmallVec::with_capacity(create_infos.len());
+        create_info: SamplerCreateInfo,
+    ) -> SamplerHandle {
+        let create_info = create_info.into();
 
-        for create_info in create_infos {
-            let create_info = create_info.clone().into();
+        let sampler = {
+            device
+                .device
+                .create_sampler(create_info)
+                .expect("Can't create sampler")
+        };
 
-            let sampler = {
-                device
-                    .device
-                    .create_sampler(create_info)
-                    .expect("Can't create sampler")
-            };
-
-            let handle = self.storage.insert(sampler);
-
-            results.push(handle);
-        }
-
-        results
+        self.storage.insert(sampler)
     }
 
     pub(crate) fn raw(&self, sampler: SamplerHandle) -> Option<&Sampler> {

--- a/nitrogen/src/resources/vertex_attrib.rs
+++ b/nitrogen/src/resources/vertex_attrib.rs
@@ -4,8 +4,6 @@
 
 use crate::storage::{Handle, Storage};
 
-use smallvec::SmallVec;
-
 pub type VertexAttribHandle = Handle<VertexAttrib>;
 
 #[derive(Debug)]

--- a/nitrogen/src/util/allocator.rs
+++ b/nitrogen/src/util/allocator.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use derive_more::{Display, From};
-
 /// The returned object representing a memory allocation
 pub(crate) trait Block: Sized {
     fn range(&self) -> std::ops::Range<u64>;

--- a/nitrogen/src/util/submit_group.rs
+++ b/nitrogen/src/util/submit_group.rs
@@ -324,15 +324,17 @@ impl SubmitGroup {
     pub unsafe fn image_upload_data(
         &mut self,
         ctx: &mut Context,
-        images: &[(image::ImageHandle, image::ImageUploadInfo)],
-    ) -> SmallVec<[image::Result<()>; 16]> {
+        image: image::ImageHandle,
+        data: image::ImageUploadInfo,
+    ) -> image::Result<()> {
         ctx.image_storage.upload_data(
             &ctx.device_ctx,
             &self.sem_pool,
             &mut self.sem_list,
             &self.pool_transfer,
             &mut self.res_destroys,
-            images,
+            image,
+            data,
         )
     }
 

--- a/nitrogen/src/util/submit_group.rs
+++ b/nitrogen/src/util/submit_group.rs
@@ -345,9 +345,11 @@ impl SubmitGroup {
     pub unsafe fn buffer_cpu_visible_upload<T>(
         &mut self,
         ctx: &mut Context,
-        data: &[(buffer::BufferHandle, buffer::BufferUploadInfo<T>)],
-    ) -> SmallVec<[buffer::Result<()>; 16]> {
-        ctx.buffer_storage.cpu_visible_upload(&ctx.device_ctx, data)
+        buffer: buffer::BufferHandle,
+        info: buffer::BufferUploadInfo<T>,
+    ) -> buffer::Result<()> {
+        ctx.buffer_storage
+            .cpu_visible_upload(&ctx.device_ctx, buffer, info)
     }
 
     pub unsafe fn buffer_cpu_visible_read<T>(
@@ -363,15 +365,17 @@ impl SubmitGroup {
     pub unsafe fn buffer_device_local_upload<T>(
         &mut self,
         ctx: &mut Context,
-        data: &[(buffer::BufferHandle, buffer::BufferUploadInfo<T>)],
-    ) -> SmallVec<[buffer::Result<()>; 16]> {
+        buffer: buffer::BufferHandle,
+        info: buffer::BufferUploadInfo<T>,
+    ) -> buffer::Result<()> {
         ctx.buffer_storage.device_local_upload(
             &ctx.device_ctx,
             &self.sem_pool,
             &mut self.sem_list,
             &self.pool_transfer,
             &mut self.res_destroys,
-            data,
+            buffer,
+            info,
         )
     }
 


### PR DESCRIPTION
I hope I didn't miss anything.

This changes most APIs (like creation or updating of resources) to no longer take slices/iterators as arguments and return `SmallVec`s, instead things are operated on one by one.

In practice it was rarely used and the usefulness questionable.

The memory allocator is no longer wrapped in a `Mutex<>` but only a `RefCell<>`. There were no intentions of the allocator actually being used from multiple threads at the same time.