### PR TITLE
add initial (simple) benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+**/target
 **/*.rs.bk
 Cargo.lock
 .idea

--- a/nitrogen/Cargo.toml
+++ b/nitrogen/Cargo.toml
@@ -24,3 +24,15 @@ gfx = { version = "0.2.0", package = "gfx-hal", default-features = false }
 back = { version = "0.2.0", package = "gfx-backend-vulkan", default-features = false }
 
 rendy-memory = { version = "0.2.0", optional = true }
+
+
+[dev-dependencies]
+criterion = "0.2.11"
+
+[[bench]]
+name = "buffer"
+harness = false
+
+[[bench]]
+name = "graph_compilation"
+harness = false

--- a/nitrogen/benches/buffer.rs
+++ b/nitrogen/benches/buffer.rs
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+mod common;
+
+use common::BenchContext;
+
+use criterion::Criterion;
+use criterion::{criterion_group, criterion_main};
+
+unsafe fn create_device_local_buffer(ctx: &mut BenchContext, size: usize) {
+    let info = nitrogen::buffer::DeviceLocalCreateInfo {
+        size: size as _,
+        is_transient: false,
+        usage: nitrogen::gfx::buffer::Usage::TRANSFER_SRC
+            | nitrogen::gfx::buffer::Usage::TRANSFER_DST,
+    };
+
+    let buf = ctx.ctx.buffer_device_local_create(info).unwrap();
+
+    ctx.group.buffer_destroy(&mut ctx.ctx, &[buf]);
+    ctx.group.wait(&mut ctx.ctx);
+}
+
+unsafe fn create_cpu_visible_buffer(ctx: &mut BenchContext, size: usize) {
+    let info = nitrogen::buffer::CpuVisibleCreateInfo {
+        size: size as _,
+        is_transient: false,
+        usage: nitrogen::gfx::buffer::Usage::TRANSFER_SRC
+            | nitrogen::gfx::buffer::Usage::TRANSFER_DST,
+    };
+
+    let buf = ctx.ctx.buffer_cpu_visible_create(info).unwrap();
+
+    ctx.group.buffer_destroy(&mut ctx.ctx, &[buf]);
+    ctx.group.wait(&mut ctx.ctx);
+}
+
+fn benchmark_device_local(c: &mut Criterion) {
+    let context = BenchContext::new();
+
+    {
+        let ctx = context.clone();
+        c.bench_function_over_inputs(
+            "create device local buffers",
+            move |b, i| {
+                b.iter(|| unsafe {
+                    let mut ctx = ctx.borrow_mut();
+                    create_device_local_buffer(&mut ctx, **i);
+                })
+            },
+            &[16, 1024, 1024 * 1024, 1024 * 1024 * 1024],
+        );
+    }
+
+    BenchContext::release(context);
+}
+
+fn benchmark_cpu_visible(c: &mut Criterion) {
+    let context = BenchContext::new();
+
+    {
+        let ctx = context.clone();
+        c.bench_function_over_inputs(
+            "create cpu visible buffers",
+            move |b, i| {
+                b.iter(|| unsafe {
+                    let mut ctx = ctx.borrow_mut();
+                    create_cpu_visible_buffer(&mut ctx, **i);
+                })
+            },
+            &[16, 1024, 1024 * 1024],
+        );
+    }
+
+    BenchContext::release(context);
+}
+
+criterion_group!(benches, benchmark_device_local, benchmark_cpu_visible);
+criterion_main!(benches);

--- a/nitrogen/benches/common.rs
+++ b/nitrogen/benches/common.rs
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub struct BenchContext {
+    pub ctx: nitrogen::Context,
+    pub group: nitrogen::SubmitGroup,
+}
+
+impl BenchContext {
+    pub fn new() -> Rc<RefCell<Self>> {
+        let context = unsafe {
+            let ctx = nitrogen::Context::new("bench", 1);
+            let group = ctx.create_submit_group();
+
+            BenchContext { ctx, group }
+        };
+
+        Rc::new(RefCell::new(context))
+    }
+
+    pub fn release(v: Rc<RefCell<Self>>) {
+        let context = Rc::try_unwrap(v).ok().unwrap().into_inner();
+        unsafe {
+            let mut ctx = context.ctx;
+            let submit = context.group;
+
+            submit.release(&mut ctx);
+            ctx.release();
+        };
+    }
+}

--- a/nitrogen/benches/graph_compilation.rs
+++ b/nitrogen/benches/graph_compilation.rs
@@ -1,0 +1,187 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+mod common;
+
+use criterion::{black_box, Criterion};
+use criterion::{criterion_group, criterion_main};
+
+#[derive(Copy, Clone)]
+enum GraphDependencyType {
+    Deep,
+    Flat,
+}
+
+fn build_graph(num_middle_passes: usize, t: GraphDependencyType) -> nitrogen::graph::GraphBuilder {
+    let mut builder = nitrogen::graph::GraphBuilder::new("BenchMark graph");
+
+    {
+        struct InitialPass;
+
+        impl nitrogen::graph::ComputePass for InitialPass {
+            type Config = ();
+
+            fn configure(&self, config: &Self::Config) -> nitrogen::graph::ComputePipelineInfo {
+                unimplemented!()
+            }
+
+            fn describe(&mut self, res: &mut nitrogen::graph::ResourceDescriptor) {
+                res.virtual_create("Initial");
+            }
+
+            unsafe fn execute(
+                &self,
+                store: &nitrogen::graph::Store,
+                dispatcher: &mut nitrogen::graph::ComputeDispatcher<Self>,
+            ) -> Result<(), nitrogen::graph::GraphExecError> {
+                unimplemented!()
+            }
+        }
+
+        builder.add_compute_pass("Initial", InitialPass);
+    }
+
+    for i in 0..num_middle_passes {
+        struct MiddlePass {
+            t: GraphDependencyType,
+            n: usize,
+        }
+
+        impl nitrogen::graph::ComputePass for MiddlePass {
+            type Config = ();
+
+            fn configure(&self, config: &Self::Config) -> nitrogen::graph::ComputePipelineInfo {
+                unimplemented!()
+            }
+
+            fn describe(&mut self, res: &mut nitrogen::graph::ResourceDescriptor) {
+                let dependency = match self.t {
+                    GraphDependencyType::Deep => {
+                        if self.n == 0 {
+                            "Initial".to_string()
+                        } else {
+                            format!("Res{}", self.n - 1)
+                        }
+                    }
+                    GraphDependencyType::Flat => "Initial".to_string(),
+                };
+
+                res.virtual_read(dependency);
+
+                res.virtual_create(format!("Res{}", self.n));
+            }
+
+            unsafe fn execute(
+                &self,
+                store: &nitrogen::graph::Store,
+                dispatcher: &mut nitrogen::graph::ComputeDispatcher<Self>,
+            ) -> Result<(), nitrogen::graph::GraphExecError> {
+                unimplemented!()
+            }
+        }
+
+        builder.add_compute_pass(format!("Middle{}", i), MiddlePass { t, n: i });
+    }
+
+    {
+        struct LastPass {
+            t: GraphDependencyType,
+            n: usize,
+        }
+
+        impl nitrogen::graph::ComputePass for LastPass {
+            type Config = ();
+
+            fn configure(&self, config: &Self::Config) -> nitrogen::graph::ComputePipelineInfo {
+                unimplemented!()
+            }
+
+            fn describe(&mut self, res: &mut nitrogen::graph::ResourceDescriptor) {
+                match self.t {
+                    GraphDependencyType::Deep => {
+                        // depend on the the very last one
+                        res.virtual_read(format!("Res{}", self.n - 1));
+                    }
+                    GraphDependencyType::Flat => {
+                        // depend on all the middle ones
+                        for i in 0..self.n {
+                            res.virtual_read(format!("Res{}", i));
+                        }
+                    }
+                }
+
+                res.virtual_create("Final");
+            }
+
+            unsafe fn execute(
+                &self,
+                store: &nitrogen::graph::Store,
+                dispatcher: &mut nitrogen::graph::ComputeDispatcher<Self>,
+            ) -> Result<(), nitrogen::graph::GraphExecError> {
+                unimplemented!()
+            }
+        }
+
+        builder.add_compute_pass(
+            "Last",
+            LastPass {
+                t,
+                n: num_middle_passes,
+            },
+        );
+    }
+
+    builder.add_target("Final");
+
+    builder
+}
+
+unsafe fn compile_graph(
+    ctx: &mut common::BenchContext,
+    num_middle_passes: usize,
+    t: GraphDependencyType,
+) {
+    let builder = build_graph(num_middle_passes, t);
+
+    let graph = black_box(ctx.ctx.graph_create(builder).unwrap());
+
+    ctx.group.graph_destroy(&mut ctx.ctx, &[graph]);
+}
+
+fn benchmark_graph_compilation(c: &mut Criterion) {
+    let ctx = common::BenchContext::new();
+
+    {
+        let ctx = ctx.clone();
+
+        c.bench_function_over_inputs(
+            "build_graph_deep",
+            move |b, i| {
+                b.iter(|| unsafe {
+                    compile_graph(&mut ctx.borrow_mut(), *i, GraphDependencyType::Deep)
+                });
+            },
+            (0..10).map(|i| 1 << i),
+        );
+    }
+
+    {
+        let ctx = ctx.clone();
+
+        c.bench_function_over_inputs(
+            "build_graph_flat",
+            move |b, i| {
+                b.iter(|| unsafe {
+                    compile_graph(&mut ctx.borrow_mut(), *i, GraphDependencyType::Flat)
+                });
+            },
+            (0..10).map(|i| 1 << i),
+        );
+    }
+
+    common::BenchContext::release(ctx);
+}
+
+criterion_group!(bench, benchmark_graph_compilation);
+criterion_main!(bench);


### PR DESCRIPTION
Right now only buffer creation and graph compilation are measured.

The buffer-creation is not that interesting actually, apart from seeing that different allocators have different performance. This benchmark might go away in future, but maybe not.

The other is graph compilation which is more interesting as changes to the compilation algorithms can be checked for performance regressions now.

Also the `rendy-memory` wrapping code is a lot nicer now thanks to input from @memoryruins :blue_heart: 